### PR TITLE
Afform - defer rendering a tab's contents until it is first shown

### DIFF
--- a/ext/afform/core/ang/af/afTabset.component.js
+++ b/ext/afform/core/ang/af/afTabset.component.js
@@ -116,6 +116,13 @@
         }
       };
 
+      // Deferring a tab's contents until it is first shown avoids running every embedded
+      // search and prefill on page load. Two cases must stay eager:
+      // - a submission form, because an unrendered `af-fieldset` never registers with
+      //   `afForm` and its values would be silently dropped from the submission;
+      // - page-nav mode, because `findInvalid()` gates forward navigation on the DOM.
+      this.isLazy = () => !this.afFormCtrl && !this.pageNavButtons;
+
       this.getFormName = () => this.afFormCtrl?.getFormMeta().name ?? $scope.$parent.meta.name;
 
       this.getCacheKey = () => this.getFormName() + 'SelectedTab';
@@ -135,11 +142,22 @@
       // Transclude allows the tab scope to be accessed from the inner html as $parent
       transclude: true,
       // ngShow will toggle the class `ng-hide`; also adding it to the markup avoids initial flash
-      template: '<div ng-transclude role="tabpanel" ng-show="afTabsetCtrl.selectedTab === name" class="ng-hide"></div>',
+      template: '<div ng-transclude role="tabpanel" ng-if="rendered" ng-show="afTabsetCtrl.selectedTab === name" class="ng-hide"></div>',
       link: function (scope, element, attrs, afTabsetCtrl) {
         scope.name = scope.name || 'tab' + tabNumber++;
         scope.afTabsetCtrl = afTabsetCtrl;
         scope.findInvalid = () => element.find('.ng-invalid');
+        // Render on first selection, then keep the contents alive so that tab state
+        // and unsaved input survive switching away and back.
+        scope.rendered = !afTabsetCtrl.isLazy();
+        if (!scope.rendered) {
+          const stopWatching = scope.$watch(() => afTabsetCtrl.selectedTab === scope.name, (isSelected) => {
+            if (isSelected) {
+              scope.rendered = true;
+              stopWatching();
+            }
+          });
+        }
         afTabsetCtrl.addTab(scope);
       }
     };

--- a/tests/karma/unit/afTabsetSpec.js
+++ b/tests/karma/unit/afTabsetSpec.js
@@ -1,0 +1,132 @@
+'use strict';
+
+describe('afTabset', function() {
+
+  var $compile, $rootScope, $timeout, scope;
+
+  // Each tab holds a marked input, so a spec can see which tabs are in the DOM
+  // and whether their contents are the same nodes as before.
+  var TABS =
+    '<af-tab name="one" title="One"><input class="probe" data-tab="one"></af-tab>' +
+    '<af-tab name="two" title="Two"><input class="probe" data-tab="two"></af-tab>' +
+    '<af-tab name="three" title="Three"><input class="probe" data-tab="three"></af-tab>';
+
+  beforeEach(function() {
+    module('crmResource');
+    module('af');
+    // afForm injects crmApi4, which `af` does not itself require - on a real page it
+    // arrives via afCore. @see ext/afform/core/ang/afCore.ang.php
+    module('api4');
+    module('angularFileUpload');
+  });
+
+  beforeEach(inject(['crmLegacy', function(crmLegacy) {
+    // afForm builds its file-upload url as it is constructed, and CRM.url needs its
+    // templates set once per browser session - which a real page does and karma does not.
+    crmLegacy.url({
+      back: '/civicrm/crmajax-placeholder-url-path?civicrm-placeholder-url-query=1',
+      front: '/civicrm/crmajax-placeholder-url-path?civicrm-placeholder-url-query=1'
+    });
+  }]));
+
+  beforeEach(inject(function(_$compile_, _$rootScope_, _$timeout_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $timeout = _$timeout_;
+  }));
+
+  function build(html) {
+    scope = $rootScope.$new();
+    // With no af-form, afTabset reads the form name off the parent scope.
+    scope.meta = {name: 'testForm'};
+    var element = $compile(html)(scope);
+    scope.$digest();
+    return element;
+  }
+
+  // Names of the tabs whose contents are currently in the DOM, in document order.
+  function inDom(element) {
+    return Array.prototype.map.call(element[0].querySelectorAll('.probe'), function(el) {
+      return el.getAttribute('data-tab');
+    });
+  }
+
+  function probe(element, name) {
+    return element[0].querySelector('.probe[data-tab="' + name + '"]');
+  }
+
+  function tabsetCtrl(element) {
+    var el = element[0].matches('af-tabset') ? element[0] : element[0].querySelector('af-tabset');
+    return angular.element(el).isolateScope().$ctrl;
+  }
+
+  describe('outside a submission form', function() {
+
+    it('renders only the selected tab', function() {
+      var element = build('<af-tabset>' + TABS + '</af-tabset>');
+      // The initial selection is made in a $timeout.
+      $timeout.flush();
+
+      expect(tabsetCtrl(element).selectedTab).toBe('one');
+      expect(inDom(element)).toEqual(['one']);
+    });
+
+    it('renders a tab the first time it is selected', function() {
+      var element = build('<af-tabset>' + TABS + '</af-tabset>');
+      $timeout.flush();
+
+      tabsetCtrl(element).selectTab('three');
+      scope.$digest();
+
+      expect(inDom(element)).toEqual(['one', 'three']);
+    });
+
+    it('keeps a tab rendered after switching away, so unsaved input survives', function() {
+      var element = build('<af-tabset>' + TABS + '</af-tabset>');
+      $timeout.flush();
+      tabsetCtrl(element).selectTab('three');
+      scope.$digest();
+
+      var input = probe(element, 'three');
+      input.value = 'unsaved text';
+
+      tabsetCtrl(element).selectTab('one');
+      scope.$digest();
+
+      expect(inDom(element)).toEqual(['one', 'three']);
+      // The same node, not a fresh one - which is what preserves the input.
+      expect(probe(element, 'three')).toBe(input);
+      expect(probe(element, 'three').value).toBe('unsaved text');
+    });
+
+  });
+
+  describe('where deferring would change behaviour', function() {
+
+    it('renders every tab up front inside a submission form', function() {
+      // An unrendered af-fieldset never registers with afForm, so its values would be
+      // dropped from the submission.
+      var element = build('<af-form ctrl="afform" ng-form="testForm">' +
+        '<af-tabset>' + TABS + '</af-tabset>' +
+        '</af-form>');
+      // No $timeout.flush(): afForm prefills in a $timeout, and this is only about what
+      // is in the DOM once the form has linked.
+
+      expect(inDom(element)).toEqual(['one', 'two', 'three']);
+    });
+
+    it('renders every tab up front in page-nav mode', function() {
+      // findInvalid() gates forward navigation by searching the DOM.
+      var element = build('<af-tabset page-nav-buttons="true">' + TABS + '</af-tabset>');
+      $timeout.flush();
+
+      expect(inDom(element)).toEqual(['one', 'two', 'three']);
+      expect(tabsetCtrl(element).tabs.length).toBe(3);
+      tabsetCtrl(element).tabs.forEach(function(tab) {
+        expect(tab.findInvalid().length).toBe(0);
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
Overview
----------------------------------------

An `<af-tabset>` renders every tab up front, so a page built out of tabs runs the work for all of them on load even though only one is visible. On a portal- or dashboard-style form that means every embedded search display queries and every embedded form prefills before the user has clicked anything.

Tabs now render on first selection and stay rendered afterwards, so the saving is on page load and nothing is re-fetched when the user comes back to a tab.

Two cases deliberately stay eager, because deferring them would change behaviour rather than just defer it — see Technical Details.

Before
----------------------------------------

Every tab's contents are in the DOM from the start. `af-tab`'s template is:

```js
template: '<div ng-transclude role="tabpanel" ng-show="afTabsetCtrl.selectedTab === name" class="ng-hide"></div>',
```

`ng-show` only toggles a class, so a four-tab search form containing two search displays and one embedded form issues all of their API calls immediately.

After
----------------------------------------

Measured on a four-tab search-type Afform (`Dashboard` / `Update your details` / `My contacts` / `Groups`), where tab 2 embeds a submission form and tabs 3 and 4 each embed a search display. Counts are `civicrm/ajax` entries from the browser's Resource Timing data:

| Action | `civicrm/ajax` calls | Tabs rendered |
| --- | --- | --- |
| Page load | **0** (was 4) | `welcome` only |
| Select `My contacts` | +2 (`SearchDisplay/run` + its metadata read) | `welcome`, `contacts` |
| Select `Update your details` | +1 (prefill) | + `details` |
| Back to `Dashboard`, then to `Update your details` again | **+0** | unchanged |

`Groups` was never selected, so its search display was never added to the DOM and never queried.

Because a rendered tab is kept alive rather than destroyed, unsaved input survives switching away and back: text typed into the `Update your details` tab was still there after navigating to `Dashboard` and returning.

Technical Details
----------------------------------------

Laziness is decided by `afTabset`:

```js
this.isLazy = () => !this.afFormCtrl && !this.pageNavButtons;
```

Both exclusions are load-bearing:

- **Submission forms** (`afFormCtrl` present). An unrendered `af-fieldset` never registers with `afForm`, so its values would be silently dropped from the submission — a data-loss bug, not a slower page. Verified: on a `type: form` Afform with one fieldset per tab, `isLazy()` is `false`, both tabs' fields are in the DOM on load, and submitting after filling a field on a tab that was never displayed created the contact with both values (`first_name` from the visible tab, `last_name` from the hidden one).
- **Page-nav / wizard mode** (`page-nav-buttons`). `selectTab()` gates forward navigation on `this.tabs[currentIndex]?.findInvalid()`, which is `element.find('.ng-invalid')` — a DOM query, and an unrendered tab has no DOM to search. Verified: with `page-nav-buttons="true"` on the same search form, `isLazy()` is `false`, all four tabs render on load and `findInvalid()` still resolves.

The per-tab watcher unregisters itself once the tab has rendered, so it costs one digest check per unvisited tab and nothing thereafter.

Comments
----------------------------------------

Second commit adds `tests/karma/unit/afTabsetSpec.js` — five specs, the first karma coverage for any `af` runtime directive (`ext/afform/core/ang/**` is already in `karma.conf.js`'s `files` list, so no config change was needed):

- renders only the selected tab
- renders a tab the first time it is selected
- keeps a tab rendered after switching away, asserting the contents are the *same* DOM node and an input's value survives — which is what makes unsaved input safe
- renders every tab up front inside a submission form
- renders every tab up front in page-nav mode

Results: **86 passing** (81 pre-existing + 5 new). With the component reverted to its current form and the specs kept, the three deferred specs fail with `Expected $.length = 3 to equal 1` / `to equal 2` — all three tabs in the DOM — while the two eager specs pass either way, which is the point of them.

Two incidental notes for anyone running karma locally:

- `karma.conf.js` sets `browsers: ['ChromeHeadless']` but `karma-chrome-launcher` is not in `devDependencies`, so `npm install && npm test` in a fresh checkout fails with `Cannot load browser "ChromeHeadless": it is not registered!`. Karma globs `karma-*` as siblings of its own install directory rather than using node resolution, so a copy further up the tree is not picked up. Happy to send that as a separate one-line PR.
- `singleRun: false` and `autoWatch: true`, so a scripted run needs `karma start --single-run`.

The spec loads `api4` and `angularFileUpload` explicitly: `afForm` injects `crmApi4`, which the `af` module does not itself require — on a real page it arrives via `afCore`.

Runtime behaviour was also verified in a browser against a standalone build (CiviCRM 6.20.alpha1); `civilint` clean.

@colemanw Extracted from afDashboard work
