### PR TITLE
Fix two snags with normalised `kcfinder` routes.

### DIFF
--- a/CRM/Badge/Form/Layout.php
+++ b/CRM/Badge/Form/Layout.php
@@ -42,11 +42,6 @@ class CRM_Badge_Form_Layout extends CRM_Admin_Form {
     }
 
     $resources = CRM_Core_Resources::singleton();
-    $resources->addSetting(
-      [
-        'kcfinderPath' => CRM_Utils_File::addTrailingSlash(Civi::paths()->getVariable('civicrm.packages', 'url'), '/'),
-      ]
-    );
     $resources->addScriptFile('civicrm', 'templates/CRM/Badge/Form/Layout.js', 1, 'html-header');
 
     $this->applyFilter('__ALL__', 'trim');

--- a/ext/ckeditor4/Civi/Kcfinder.php
+++ b/ext/ckeditor4/Civi/Kcfinder.php
@@ -83,6 +83,9 @@ class Kcfinder extends AutoService implements EventSubscriberInterface {
       'img/icons/settings.png' => "{$imageBaseUrl}/icons/settings.png",
       'img/icons/maximize.png' => "{$imageBaseUrl}/icons/maximize.png",
       'img/icons/about.png' => "{$imageBaseUrl}/icons/about.png",
+      'img/tree/folder.png' => "{$imageBaseUrl}/tree/folder.png",
+      'img/tree/plus.png' => "{$imageBaseUrl}/tree/plus.png",
+      'img/tree/minus.png' => "{$imageBaseUrl}/tree/minus.png",
     ];
 
     foreach ($replacements as $old => $new) {

--- a/templates/CRM/Badge/Form/Layout.js
+++ b/templates/CRM/Badge/Form/Layout.js
@@ -18,7 +18,7 @@ CRM.$(function($) {
       }
     };
 
-    window.open(CRM.kcfinderPath + 'kcfinder/browse.php?cms=civicrm&type=images', 'kcfinder_textbox',
+    window.open(CRM.url('civicrm/kcfinder/browse?type=images'), 'kcfinder_textbox',
       'status=0, toolbar=0, location=0, menubar=0, directories=0, ' +
         'resizable=1, scrollbars=0, width=800, height=600'
     );


### PR DESCRIPTION
Overview
----------------------------------------
Fix for Event Badge layout and tree view icons

Before
----------------------------------------
- adding images from the Event Badge layout gives "Path not found" error
- the icons are missing from the tree view in the `kcfinder`

<img width="250" height="310" alt="image" src="https://github.com/user-attachments/assets/0792bf31-860b-4458-b869-5335cb1053e7" />


After
----------------------------------------
- adding images from the Event Badge layout works as before
- the icons are show in the tree view in the `kcfinder`

<img width="285" height="345" alt="image" src="https://github.com/user-attachments/assets/4740c6c3-2856-4e7f-9405-6430c311ba78" />

