### PR TITLE
[draft] Afform - support Symfony Expression Language for conditionals

### DIFF
--- a/ang/crmSel.ang.php
+++ b/ang/crmSel.ang.php
@@ -5,5 +5,6 @@ return [
   'js' => [
     'ang/crmSel.js',
     'bower_components/typescript-expression-language/dist/index.umd.js',
+    'bower_components/typescript-expression-language/dist/providers.umd.js',
   ],
 ];

--- a/ang/crmSel.ang.php
+++ b/ang/crmSel.ang.php
@@ -1,0 +1,9 @@
+<?php
+// This file declares an Angular module which can be autoloaded
+return [
+  'ext' => 'civicrm',
+  'js' => [
+    'ang/crmSel.js',
+    'bower_components/typescript-expression-language/dist/index.umd.js',
+  ],
+];

--- a/ang/crmSel.js
+++ b/ang/crmSel.js
@@ -1,0 +1,3 @@
+(function(angular) {
+  angular.module('crmSel', CRM.angRequires('crmSel'));
+})(angular);

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,8 @@
     "pontedilana/php-weasyprint": "^0.13.0 || ^1 || ^2",
     "knplabs/knp-snappy": "^1.4",
     "phpseclib/phpseclib2_compat": "^1.0",
-    "smarty/smarty": "^5.8.4"
+    "smarty/smarty": "^5.8.4",
+    "symfony/expression-language": "^6.4"
   },
   "scripts": {
     "post-install-cmd": [
@@ -295,6 +296,11 @@
       "sms-counter": {
         "url": "https://github.com/danxexe/sms-counter/archive/master.zip",
         "ignore": ["examples"]
+      },
+      "typescript-expression-language": {
+	"url": "https://registry.npmjs.org/@andreasnicolaou/typescript-expression-language/-/typescript-expression-language-3.0.0.tgz",
+        "path": "bower_components/typescript-expression-language",
+        "ignore": ["*.cjs", "*.ts"]
       }
     },
     "patches-comments": "For information about defining patches via composer.json, see ./tools/patches/README.md and https://docs.civicrm.org/dev/en/latest/core/dependencies/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0fbbecb6eb879bfc0525cbd86702d96",
+    "content-hash": "f7236cec6df54e6a6b247e92728774e4",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -3481,6 +3481,55 @@
             "time": "2026-06-03T07:20:31+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.1.0",
             "source": {
@@ -4212,6 +4261,186 @@
             "time": "2023-01-06T09:28:15+00:00"
         },
         {
+            "name": "symfony/cache",
+            "version": "v6.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "ea9758447aa48581e2e2c0d318782d89e2182136"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/ea9758447aa48581e2e2c0d318782d89e2182136",
+                "reference": "ea9758447aa48581e2e2c0d318782d89e2182136",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/cache": "^2.0|^3.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/var-exporter": "^6.3.6|^7.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.13.1",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/var-dumper": "<5.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "2.0|3.0",
+                "psr/simple-cache-implementation": "1.0|2.0|3.0",
+                "symfony/cache-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.18",
+                "doctrine/dbal": "^2.13.1|^3|^4",
+                "predis/predis": "^1.1|^2.0",
+                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "classmap": [
+                    "Traits/ValueWrapper.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v6.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-30T20:10:39+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "9789738bc19af1106dc54d6afba9a0b467516cf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/9789738bc19af1106dc54d6afba9a0b467516cf2",
+                "reference": "9789738bc19af1106dc54d6afba9a0b467516cf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/cache": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
             "name": "symfony/config",
             "version": "v6.4.37",
             "source": {
@@ -4678,6 +4907,74 @@
                 }
             ],
             "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v6.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "91edabba1aff9da3326eee2a6e7666d1c1270751"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/91edabba1aff9da3326eee2a6e7666d1c1270751",
+                "reference": "91edabba1aff9da3326eee2a6e7666d1c1270751",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/cache": "^5.4|^6.0|^7.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an engine that can compile and evaluate expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/expression-language/tree/v6.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-30T00:27:22+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -6342,7 +6639,7 @@
     "minimum-stability": "stable",
     "stability-flags": {},
     "prefer-stable": false,
-    "prefer-lowest": true,
+    "prefer-lowest": false,
     "platform": {
         "php": "^8.1.2",
         "ext-bcmath": "*",

--- a/ext/afform/core/ang/af.ang.php
+++ b/ext/afform/core/ang/af.ang.php
@@ -8,7 +8,7 @@ return [
   ],
   // 'css' => ['ang/af.css'],
   'partials' => ['ang/af'],
-  'requires' => ['crmUtil'],
+  'requires' => ['crmUtil', 'crmSel'],
   'basePages' => [],
   'exports' => [
     'af-entity' => 'E',

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -93,23 +93,26 @@
         }
 
         // Watch conditional required attribute
+        // TODO: in future we may be able to optimise this to only recalculate
+        // the conditional if tokens with the attribute change. at this point
+        // in time there could be a combo of tokens [Individual1.0.first_name]
+        // and angular expressions Individual1[0]['fields']['last_name']
+        // the latter are harder to watch
         const afRequiredAttr = $element.attr('af-required');
         if (afRequiredAttr) {
-          $scope.$watch(() => {
-            return ctrl.afForm.evaluateExpression(afRequiredAttr);
-          }, (value) => {
-            ctrl.defn.required = value;
-          });
+          $scope.$watch(
+            () => this.afForm.checkConditional(afRequiredAttr),
+            (value) => this.defn.required = value
+          );
         }
 
         // Watch conditional disabled attribute
         const afDisabledAttr = $element.attr('af-disabled');
         if (afDisabledAttr) {
-          $scope.$watch(() => {
-            return ctrl.afForm.evaluateExpression(afDisabledAttr);
-          }, (value) => {
-            ctrl.defn.disabled = value;
-          });
+          $scope.$watch(
+            () => this.afForm.checkConditional(afDisabledAttr),
+            (value) => this.defn.disabled = value
+          );
         }
 
         // check for tokens in the default value
@@ -450,14 +453,7 @@
         return fieldOptions.filter((opt) => {
           if (!opt.if || !opt.if.length) return true;
           try {
-            let expression = opt.if;
-
-            // support legacy bespoke conditional arrays
-            // note angular expects a quoted expression
-            if (Array.isArray(opt.if)) {
-              expression = "'" + JSON.stringify(expression) + "'";
-            }
-            return this.afForm.evaluateExpression(opt.if);
+            return this.afForm.checkConditional(opt.if);
           } catch (e) {
             // Permissive: misconfigured rule => visible. Server-side checks
             // are still authoritative.

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -114,7 +114,7 @@
 
         // check for tokens in the default value
         const tokens = this.afForm?.identifyTokens(this.defn.afform_default);
-        if (tokens && tokens.size) {
+        if (tokens) {
           const calculateValueWatcher = $scope.$watchCollection(() => Object.values(this.afForm.getTokenValues(tokens)), () => {
             if ($element[0].querySelector('.ng-touched')) {
               // user has touched this input, stop calculating

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -96,8 +96,7 @@
         const afRequiredAttr = $element.attr('af-required');
         if (afRequiredAttr) {
           $scope.$watch(() => {
-            const conditions = $scope.$eval(afRequiredAttr);
-            return ctrl.afForm.checkConditions(conditions);
+            return ctrl.afForm.evaluateExpression(afRequiredAttr);
           }, (value) => {
             ctrl.defn.required = value;
           });
@@ -107,8 +106,7 @@
         const afDisabledAttr = $element.attr('af-disabled');
         if (afDisabledAttr) {
           $scope.$watch(() => {
-            const conditions = $scope.$eval(afDisabledAttr);
-            return ctrl.afForm.checkConditions(conditions);
+            return ctrl.afForm.evaluateExpression(afDisabledAttr);
           }, (value) => {
             ctrl.defn.disabled = value;
           });
@@ -452,7 +450,14 @@
         return fieldOptions.filter((opt) => {
           if (!opt.if || !opt.if.length) return true;
           try {
-            return this.afForm.checkConditions(opt.if);
+            let expression = opt.if;
+
+            // support legacy bespoke conditional arrays
+            // note angular expects a quoted expression
+            if (Array.isArray(opt.if)) {
+              expression = "'" + JSON.stringify(expression) + "'";
+            }
+            return this.afForm.evaluateExpression(opt.if);
           } catch (e) {
             // Permissive: misconfigured rule => visible. Server-side checks
             // are still authoritative.

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -243,7 +243,11 @@
         }
 
         // default legacy bespoke expressions
-        const conditions = $parse(expression)();
+        // NOTE: this previously used $parse in some places, $eval in others
+        // but serverside uses solely json_decode -- so switching to pure
+        // function here
+        expression = expression.substring(1, expression.length - 1)
+        const conditions = JSON.parse(expression);
         return this.checkConditions(conditions);
       }
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -19,7 +19,10 @@
         extra: {fields: {}},
       };
 
-      this.expressionLanguage = new typescriptExpressionLanguage.ExpressionLanguage();
+      const { ExpressionLanguage } = typescriptExpressionLanguage;
+      const { StringProvider, ArrayProvider } = typescriptExpressionLanguageProviders;
+
+      this.expressionLanguage = new ExpressionLanguage(null, [new StringProvider(), new ArrayProvider()]);
 
       let
         args,

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -241,50 +241,62 @@
 
       this.evaluateExpression = (expression) => {
         if (expression.startsWith('sel:')) {
+          expression = expression.substring(4);
           expression = this.replaceTokens(expression);
-          return this.expressionLanguage.evaluate(expression.substring(4));
+          return this.expressionLanguage.evaluate(expression);
         }
 
-        // default legacy bespoke expressions
-        // NOTE: this previously used $parse in some places, $eval in others
-        // but serverside uses solely json_decode -- so switching to pure
-        // function here
-        expression = expression.substring(1, expression.length - 1)
-        const conditions = JSON.parse(expression);
-        return this.checkConditions(conditions);
+        throw new Error('Cannot evaluate unrecognised expression :' + expression);
       }
 
-      // Handle the logic for conditional fields
-      this.checkConditions = function(conditions, op) {
-        op = op || 'AND';
-        // OR and AND have the opposite behavior so the logic is inverted
-        // NOT works identically to OR but gets flipped at the end
-        let ret = op === 'AND',
-          flip = !ret;
-        _.each(conditions, function(clause) {
-          // Recurse into nested group
-          if (Array.isArray(clause[1])) {
-            if (ctrl.checkConditions(clause[1], clause[0]) === flip) {
-              ret = flip;
-            }
-          } else {
-            // Angular can't handle expressions with quotes inside brackets, so they are omitted
-            // Here we add them back to make valid js
-            if (typeof clause[0] === 'string' && clause[0].charAt(0) !== '"') {
-              clause[0] = clause[0].replace(/\[([^'"])/g, "['$1").replace(/([^'"])]/g, "$1']");
-            }
-            let parser1 = $parse(clause[0]);
-            let parser2 = $parse(clause[2]);
-            let result = compareConditions(parser1(data), clause[1], parser2(data));
-            if (result === flip) {
-              ret = flip;
-            }
+      this.checkConditional = (conditional) => {
+        if (Array.isArray(conditional)) {
+          // treat array of arrays as implicit AND
+          if (conditional.every((c) => Array.isArray(c))) {
+            return conditional.every((c) => this.checkConditional(c));
           }
-        });
-        return op === 'NOT' ? !ret : ret;
+          switch (conditional[0]) {
+            case 'AND':
+              return conditional[1].every((c) => this.checkConditional(c));
+
+            case 'OR':
+              return conditional[1].some((c) => this.checkConditional(c));
+
+            case 'NOT':
+              return !this.checkConditional(conditional[1]);
+
+            default:
+              return compareConditions(conditional[0], conditional[1], conditional[2]);
+          }
+        }
+
+        // strip redundant quotes and brackets from old angular expressions
+        while (conditional.startsWith('"') || conditional.startsWith("'") || conditional.startsWith('(')) {
+          conditional = conditional.substring(1, conditional.length - 1)
+        }
+
+        // parse JSON strings into arrays
+        // NOTE: this previously used $parse in some places, $eval in others
+        // but serverside uses solely json_decode -- so switching to pure
+        // parsing here
+        if (conditional.startsWith('[')) {
+          conditional = JSON.parse(conditional);
+          return this.checkConditional(conditional);
+        }
+
+        // evaluate string conditionals
+        return this.evaluateExpression(conditional);
       };
 
-      function compareConditions(val1, op, val2) {
+      const compareConditions = (val1, op, val2) => {
+        // Angular can't handle expressions with quotes inside brackets, so they are omitted
+        // Here we add them back to make valid js
+        if (typeof val1 === 'string' && !val1.startsWith('"')) {
+          val1 = val1.replace(/\[([^'"])/g, "['$1").replace(/([^'"])]/g, "$1']");
+        }
+        val1 = $parse(val1)(data);
+        val2 = $parse(val2)(data);
+
         const yes = (op !== '!=' && !op.includes('NOT '));
 
         switch (op) {

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -626,7 +626,6 @@
           return null;
         }
         const tokens = new Set(message.match(/\[[a-zA-Z0-9_]+\.[0-9]+\.[^\]]+\]/g));
-
         return tokens.size ? tokens : null;
       };
 
@@ -651,8 +650,10 @@
 
       this.replaceTokens = (message) => {
         const tokens = this.identifyTokens(message);
-        const tokenValues = this.getTokenValues(tokens);
-        tokens.forEach((token) => message = message.replaceAll(token, tokenValues[token]));
+        if (tokens) {
+          const tokenValues = this.getTokenValues(tokens);
+          tokens.forEach((token) => message = message.replaceAll(token, tokenValues[token]));
+        }
         return message;
       };
     }

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -19,6 +19,9 @@
         extra: {fields: {}},
       };
 
+      this.expressionLanguage = new typescriptExpressionLanguage.ExpressionLanguage();
+      // TODO: add custom stuff with context/tokens
+
       let
         args,
         submissionResponse,
@@ -232,6 +235,16 @@
           },
           true
         );
+      }
+
+      this.evaluateExpression = (expression) => {
+        if (expression.startsWith('sel:')) {
+          return this.expressionLanguage.evaluate(expression.substring(4));
+        }
+
+        // default legacy bespoke expressions
+        const conditions = $parse(expression)();
+        return this.checkConditions(conditions);
       }
 
       // Handle the logic for conditional fields

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -20,7 +20,6 @@
       };
 
       this.expressionLanguage = new typescriptExpressionLanguage.ExpressionLanguage();
-      // TODO: add custom stuff with context/tokens
 
       let
         args,
@@ -239,6 +238,7 @@
 
       this.evaluateExpression = (expression) => {
         if (expression.startsWith('sel:')) {
+          expression = this.replaceTokens(expression);
           return this.expressionLanguage.evaluate(expression.substring(4));
         }
 

--- a/ext/afform/core/ang/af/afIf.directive.js
+++ b/ext/afform/core/ang/af/afIf.directive.js
@@ -1,5 +1,5 @@
 (function(angular, $, _) {
-  // A modified version of ngIf to use afform.checkConditions
+  // A modified version of ngIf to use afform.checkConditional
   angular.module('af').directive('afIf', function($compile, $animate) {
     return {
       multiElement: true,
@@ -12,11 +12,9 @@
       link: function($scope, $element, $attr, ctrl, $transclude) {
         let block, childScope, previousElements;
 
-        function watcher() {
-          return ctrl[0].evaluateExpression($attr.afIf);
-        }
-
-        $scope.$watch(watcher, function(value) {
+        $scope.$watch(
+          () => ctrl[0].checkConditional($attr.afIf),
+          function(value) {
           if (value) {
             if (!childScope) {
               $transclude(function(clone, newScope) {

--- a/ext/afform/core/ang/af/afIf.directive.js
+++ b/ext/afform/core/ang/af/afIf.directive.js
@@ -1,6 +1,6 @@
 (function(angular, $, _) {
   // A modified version of ngIf to use afform.checkConditions
-  angular.module('af').directive('afIf', function($compile, $animate, $parse) {
+  angular.module('af').directive('afIf', function($compile, $animate) {
     return {
       multiElement: true,
       transclude: 'element',
@@ -13,8 +13,7 @@
         let block, childScope, previousElements;
 
         function watcher() {
-          const conditions = $parse($attr.afIf)();
-          return ctrl[0].checkConditions(conditions);
+          return ctrl[0].evaluateExpression($attr.afIf);
         }
 
         $scope.$watch(watcher, function(value) {


### PR DESCRIPTION
Overview
----------------------------------------
Allows more powerful logic, math calculations and extensibility in Afform conditionals. Work towards https://lab.civicrm.org/dev/core/-/work_items/6309

Before
----------------------------------------
Afform conditionals use a bespoke array based syntax

After
----------------------------------------
- Afform conditionals can be written using combination of Symfony Expression Language and afform tokens
- existing conditionals are still supported


Technical Details
----------------------------------------
Symfony Expression Language conditionals are identified with a prefix `sel:` 

They can use the same tokens as markup/confirmation message.. such as `[Individual1.0.first_name]`

So examples are `sel:strtolower('[Individual1.0.last_name]') === 'smith'`

So examples are `sel: 2 + 2 === 4`

Here's an example form showing new and old style conditionals working side-by-side:

```
<af-form ctrl="afform">
  <af-entity data="{source: 'SEL conditionals'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
    <af-field name="first_name" af-required="sel:strtolower('[Individual1.0.last_name]') === 'smith'" />
    <af-field name="last_name" af-required="sel: (2 + 2) === 4" />
    <af-field name="nick_name" af-if="([[&amp;quot;Individual1[0][fields][first_name]&amp;quot;,&amp;quot;IS NOT EMPTY&amp;quot;]])" af-required="([[&amp;quot;Individual1[0][fields][first_name]&amp;quot;,&amp;quot;CONTAINS&amp;quot;,&amp;quot;\&amp;quot;abc\&amp;quot;&amp;quot;]])" />
  </fieldset>
  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
</af-form>
```

The Javascript SEL implementation is included from https://github.com/andreasnicolaou/typescript-expression-language


Comments
----------------------------------------
This is just draft POC. It just adds the clientside handling, still needs:

- serverside handling (principally in `\Civi\Afform\Submit::checkAfformConditional`). 
  - the nice thing is we have symfony package
  - big gotcha -- by default the symfony package allows rendering PHP constants, we must avoid that! 
- support in the FormBuilder GUI

It would also be nice to add this to markup blocks, which would allow rendering dynamic markup based on field data.

FYI @colemanw 