### PR TITLE
CiviMail - Fix inability to remove recipients from a mailing (APIv4 EntitySet regression)

### DIFF
--- a/Civi/Api4/Query/Api4EntitySetQuery.php
+++ b/Civi/Api4/Query/Api4EntitySetQuery.php
@@ -148,6 +148,22 @@ class Api4EntitySetQuery extends Api4Query {
         $select = array_diff($select, [$item]);
       }
     }
+    // An outer expression belongs to no subquery, so without its own spec it is returned unformatted.
+    foreach ($this->selectAliases as $alias => $sql) {
+      if (isset($this->apiFieldSpec[$alias])) {
+        continue;
+      }
+      $expr = SqlExpression::convert($sql);
+      // Plain fields are resolved by base name in formatOutputValues(), which is what finds the
+      // options for a suffixed alias like `parent_id:name`; a spec keyed by the alias masks them.
+      if ($expr->getType() === 'SqlField') {
+        continue;
+      }
+      $this->addSpecField($alias, [
+        'sql_name' => "`$alias`",
+        'data_type' => $expr->getRenderedDataType($this),
+      ]);
+    }
     if ($select && !$this->isAggregateQuery()) {
       $this->selectAliases['_api_set_index'] = '_api_set_index';
       $this->query->select('`_api_set_index`');

--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -131,7 +131,7 @@ class SqlEquation extends SqlExpression {
   }
 
   /**
-   * Change $dataType according to operator used in equation
+   * Applies self::getRenderedDataType() during output formatting
    *
    * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
    * @param string|null $dataType
@@ -139,17 +139,29 @@ class SqlEquation extends SqlExpression {
    * @param string $key
    * @param Api4Query|null $query
    */
-  public function formatOutputValue(?string &$dataType, array &$values, string $key, ?Api4Query $query = NULL) {
-    foreach (self::$comparisonOperators as $op) {
-      if (strpos($this->expr, " $op ")) {
-        $dataType = 'Boolean';
-      }
-    }
+  public function formatOutputValue(?string &$dataType, array &$values, string $key, ?Api4Query $query = NULL): void {
+    $dataType = $this->getRenderedDataType($query) ?? $dataType;
+  }
+
+  /**
+   * Returns the output dataType implied by the operators used in the equation
+   *
+   * @param \Civi\Api4\Query\Api4Query|null $query
+   * @return string|null
+   */
+  public function getRenderedDataType(?Api4Query $query): ?string {
+    // Order matters: an expression using both kinds of operator is typed as Float.
     foreach (self::$arithmeticOperators as $op) {
       if (strpos($this->expr, " $op ")) {
-        $dataType = 'Float';
+        return 'Float';
       }
     }
+    foreach (self::$comparisonOperators as $op) {
+      if (strpos($this->expr, " $op ")) {
+        return 'Boolean';
+      }
+    }
+    return NULL;
   }
 
   public static function getTitle(): string {

--- a/tests/phpunit/api/v4/Action/EntitySetUnionTest.php
+++ b/tests/phpunit/api/v4/Action/EntitySetUnionTest.php
@@ -127,6 +127,56 @@ class EntitySetUnionTest extends Api4TestBase implements TransactionalInterface 
     $this->assertEquals(['Contact', 'Activity'], $result[1]['group_type:name']);
   }
 
+  public function testUnionWithOuterExpression(): void {
+    $groups = $this->saveTestRecords('Group', [
+      'records' => [
+        ['title' => 'hidden group', 'is_hidden' => TRUE],
+        ['title' => 'visible group', 'is_hidden' => FALSE],
+      ],
+    ])->column('id');
+
+    $result = EntitySet::get(FALSE)
+      ->addSelect('id', '(is_hidden = 1) AS hidden_flag')
+      ->addSet('UNION ALL', Group::get()
+        ->addSelect('id', 'is_hidden')
+        ->addWhere('id', '=', $groups[0])
+      )
+      ->addSet('UNION ALL', Group::get()
+        ->addSelect('id', 'is_hidden')
+        ->addWhere('id', '=', $groups[1])
+      )
+      ->addOrderBy('id')
+      ->execute();
+
+    $this->assertCount(2, $result);
+    // Without formatting these would be the strings "1"/"0"
+    $this->assertTrue($result[0]['hidden_flag']);
+    $this->assertFalse($result[1]['hidden_flag']);
+  }
+
+  public function testOuterExpressionNotTypedBySameNamedField(): void {
+    $tag = $this->createTestRecord('Tag', ['name' => 'union tag']);
+    $group = $this->createTestRecord('Group', ['title' => 'union group']);
+
+    $result = EntitySet::get(FALSE)
+      ->addSelect('id', 'IF((is_hidden IS NOT NULL), is_hidden, NULL) AS copied')
+      ->addSet('UNION ALL', Tag::get()
+        ->addSelect('id', 'CONCAT(name) AS is_hidden')
+        ->addWhere('id', '=', $tag['id'])
+      )
+      ->addSet('UNION ALL', Group::get()
+        ->addSelect('id', 'title')
+        ->addWhere('id', '=', $group['id'])
+      )
+      ->addOrderBy('copied')
+      ->execute();
+
+    $this->assertCount(2, $result);
+    // The union names this column after the first set's alias and both sets put a string in it,
+    // so the outer expression must not be typed from the Boolean field of that name
+    $this->assertSame(['union group', 'union tag'], $result->column('copied'));
+  }
+
   public function testGroupByUnionSet(): void {
     $contacts = $this->saveTestRecords('Contact', ['records' => 4])->column('id');
     $relationships = $this->saveTestRecords('Relationship', [


### PR DESCRIPTION
## Overview

Recipients cannot be removed from a mailing in 6.18.0. Every selected choice in the CiviMail recipients widget renders as a locked select2 choice with no remove control, and backspace does not delete it either, so there is no way to remove a recipient through the UI. Both legs of the widget's union are affected: a group's `is_hidden` yields "0" and the Mailing leg selects a literal `0`, so selected groups and selected past mailings alike come back truthy.

The cause is an APIv4 regression: an alias computed in an `EntitySet`'s own SELECT clause is returned unformatted, so the widget's `(is_hidden = 1) AS locked` arrives as the string "0" instead of `FALSE`, and "0" is truthy in JS.

## Before

`EntitySet::get()->addSelect('(is_hidden = 1) AS hidden_flag')` over two sets returns `hidden_flag` as the string "0" or "1".

## After

`hidden_flag` is a boolean, and recipients can be removed again.

## Technical Details

Nothing types an alias computed in the outer SELECT clause: `addExprToSelectClause()` records it in `selectAliases` but registers no field spec, so `FormattingUtil::formatOutputValues()` finds no `data_type` for it and passes the raw column through.

Before 7ceb8a72b these queries took the whole-result branch of `Api4EntitySetQuery::run()`, which formats using the outer `selectAliases`. There the alias resolved to a `SqlEquation`, and `SqlEquation::formatOutputValue()` supplied the Boolean. That commit added `_api_set_index` to the outer SELECT clause, which routes these queries into the per-set branch instead, and that branch formats using the subquery's aliases, where an outer-only alias does not appear.

This registers a spec for each expression computed in the EntitySet's own SELECT clause, typed through `getRenderedDataType()`, and implements that method on `SqlEquation`, which reports Boolean or Float from its operator. `formatOutputValue()` now delegates to it rather than repeating the rule.

A plain field is deliberately skipped. `Api4EntitySetQuery::getField()` resolves `parent_id:name` by stripping the suffix without storing the suffixed key, so a spec under that key would shadow the real one, and the pseudoconstant lookup in `FormattingUtil` would then be handed a NULL entity. `testUnionWithSelectStar` covers that shape.

## Tests

`testUnionWithOuterExpression` is the reported failure: it fails on master, where the assertions receive the strings "1" and "0".

`testOuterExpressionNotTypedBySameNamedField` passes on master and is a guard rather than a repro. Merging the outer aliases into the per-set ones also clears the reported symptom, but formats outer expressions with the subquery as field context, so an outer `IF()` over a union column whose name matches a real field of one set's entity takes that field's type and a title string comes back as `TRUE`. This test rejects that approach.

## Side effects worth knowing

`SqlEquation::getRenderedDataType()` has a second caller: `SavedSearchInspectorTrait::getFilterClause()` gets `NULL` for an equation today and now gets Boolean or Float. At its operator choice (`in_array($dataType, ['Integer', 'Boolean', 'Date', 'Timestamp'])`) a SearchKit filter on a comparison-expression column therefore moves from `LIKE '$value%'` to `=`, which is right for a 0/1 column. Float is not in that list, so arithmetic aliases are unaffected.

Because the aliases now resolve through `getField()`, `addWhere()` on one degrades from `Invalid field` to a MySQL 1054, since a select alias is not visible in WHERE against the derived table. GROUP BY and HAVING on such an alias improve, gaining input formatting. Both cases previously failed anyway.

Two shapes this does not address, neither of them new. An outer alias that collides with a key the subquery also selects still comes back unformatted, because `run()` merges `$subquery->apiFieldSpec + $this->apiFieldSpec`. And an unaliased outer function over a suffixed field, e.g. `IF(is_reserved, name, parent_id:label)`, throws either way: `getPseudoconstantList(): Argument #1 ($field) must be of type array, null given` on master, and `CoreUtil::getCustomGroupName(): Argument #1 ($entityName) must be of type string, null given` with this patch, because `SqlFunction::getAlias()` bakes the suffix into the alias.

## Comments

Regression in 6.18.0; 6.17.3 returns a boolean.
