### PR TITLE
Import - Re-queue a user job whose interactive run switched its queue off

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -462,7 +462,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $totalRowCount = $totalRows = $dataSource->getRowCount(['new']);
     // The retry limit for the queue is set to 5 - allowing for a few deadlocks but we might consider
     // making this configurable at some point.
-    $queue = Civi::queue('user_job_' . $this->getUserJobID(), ['type' => 'Sql', 'error' => 'abort', 'runner' => 'task', 'user_job_id' => $this->getUserJobID(), 'retry_limit' => 5]);
+    // reset: a user job can be queued again (back to the preview, run once
+    // more) after an interactive run left its queue with status NULL.
+    $queue = Civi::queue('user_job_' . $this->getUserJobID(), ['type' => 'Sql', 'error' => 'abort', 'runner' => 'task', 'user_job_id' => $this->getUserJobID(), 'retry_limit' => 5, 'reset' => TRUE]);
     UserJob::update(FALSE)
       ->setValues([
         'queue_id.name' => 'user_job_' . $this->getUserJobID(),

--- a/CRM/Queue/Service.php
+++ b/CRM/Queue/Service.php
@@ -138,6 +138,17 @@ class CRM_Queue_Service {
   protected function findCreateQueueSpec(array $queueSpec): array {
     $loaded = $this->findQueueSpec($queueSpec);
     if ($loaded !== NULL) {
+      // A queue whose background execution was switched off (status NULL,
+      // see CRM_Queue_Runner::disableBackgroundExecution) takes the caller's
+      // status again when the caller asks for a reset, e.g. an import that
+      // re-queues its user job after an interactive run.
+      if (!empty($queueSpec['reset']) && empty($loaded['status']) && !empty($queueSpec['status'])) {
+        CRM_Core_DAO::executeQuery('UPDATE civicrm_queue SET status = %1 WHERE name = %2', [
+          1 => [$queueSpec['status'], 'String'],
+          2 => [$queueSpec['name'], 'String'],
+        ]);
+        $loaded['status'] = $queueSpec['status'];
+      }
       return $loaded;
     }
 

--- a/tests/phpunit/CRM/Queue/QueueTest.php
+++ b/tests/phpunit/CRM/Queue/QueueTest.php
@@ -119,6 +119,30 @@ class CRM_Queue_QueueTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * An interactive run switches a queue's background execution off (status
+   * NULL). Re-creating it with `reset` must revive it; a plain re-create keeps
+   * failing validation.
+   */
+  public function testResetRevivesQueueWithoutStatus(): void {
+    $spec = ['type' => 'Sql', 'runner' => 'task', 'error' => 'delete'];
+    Civi::queue('test/finished', $spec);
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_queue SET status = NULL WHERE name = 'test/finished'");
+    unset(CRM_Queue_Service::singleton()->queues['test/finished']);
+
+    try {
+      Civi::queue('test/finished', $spec);
+      $this->fail('Expected the status validation to fail');
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Invalid queue status', $e->getMessage());
+    }
+
+    $q = Civi::queue('test/finished', $spec + ['reset' => TRUE]);
+    $this->assertTrue($q instanceof CRM_Queue_Queue_Sql);
+    $this->assertDBQuery('active', "SELECT status FROM civicrm_queue WHERE name = 'test/finished'");
+  }
+
   public function testTemplating(): void {
     \Civi\Api4\Queue::create()->setValues([
       'is_template' => TRUE,


### PR DESCRIPTION
## Overview

Re-running an import whose first run happened interactively crashes with `Queue spec is missing the required field: status`.

## Before

`CRM_Queue_Runner::disableBackgroundExecution()` writes `civicrm_queue.status = NULL` when the user runs the import in the browser. When the same user job is queued again (e.g. after the browser run was interrupted and the import is resumed), `CRM_Queue_Service::validateQueueSpec()` rejects the stored row and the AJAX request ends in a 500.

## After

`findCreateQueueSpec()` revives an existing queue with an empty status when the caller passes `reset` and a status, and the import parser passes `reset => TRUE` when it queues a user job. `QueueTest::testResetRevivesQueueWithoutStatus` covers the path.

## Comments

#27023 re-enables the queue at the end of `runAll()`. The web runner (`startWebRun()`) only does so in `handleEnd()`, so an import the user abandons or that aborts on error leaves `status = NULL` behind. Seen on 6.16.5; code is unchanged on master.
