### PR TITLE
civiimport - Fail the spreadsheet rule instead of crashing when no file arrived

### DIFF
--- a/ext/civiimport/Civi/Import/DataSource/Spreadsheet.php
+++ b/ext/civiimport/Civi/Import/DataSource/Spreadsheet.php
@@ -77,6 +77,11 @@ class Spreadsheet extends \CRM_Import_DataSource implements DataSourceInterface 
    * @noinspection PhpUnused
    */
   public static function isValidSpreadsheet(array $file): bool {
+    // No upload, or one PHP already discarded (over the size limit): the
+    // required and maxfilesize rules report that; identify() would throw.
+    if (empty($file['tmp_name']) || !is_readable($file['tmp_name'])) {
+      return FALSE;
+    }
     $file_type = IOFactory::identify($file['tmp_name']);
     return in_array($file_type, ['Xlsx', 'Ods']);
   }

--- a/ext/civiimport/tests/phpunit/SpreadsheetDataSourceTest.php
+++ b/ext/civiimport/tests/phpunit/SpreadsheetDataSourceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Civi\Import\DataSource\Spreadsheet;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group headless
+ */
+class SpreadsheetDataSourceTest extends TestCase implements HeadlessInterface {
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * A missing or discarded upload fails the rule instead of crashing the form.
+   */
+  public function testMissingUploadIsNotValid(): void {
+    $this->assertFalse(Spreadsheet::isValidSpreadsheet(['tmp_name' => '']));
+    $this->assertFalse(Spreadsheet::isValidSpreadsheet(['tmp_name' => '/nonexistent/upload.xlsx']));
+    $this->assertFalse(Spreadsheet::isValidSpreadsheet([]));
+  }
+
+  public function testTextFileIsNotValid(): void {
+    $path = tempnam(sys_get_temp_dir(), 'civiimport');
+    file_put_contents($path, "a,b\n1,2\n");
+    $this->assertFalse(Spreadsheet::isValidSpreadsheet(['tmp_name' => $path]));
+    unlink($path);
+  }
+
+}


### PR DESCRIPTION
## Overview

Submitting the spreadsheet import form without a file (or after PHP dropped the upload, e.g. `upload_max_filesize`) throws instead of failing the validation rule.

## Before

`Spreadsheet::isValidSpreadsheet()` hands the empty `tmp_name` to `IOFactory::identify()`, which throws `PhpOffice\PhpSpreadsheet\Reader\Exception` and surfaces as an unhandled 500.

## After

The rule returns FALSE when there is no readable upload, so the form shows the normal validation message. New `SpreadsheetDataSourceTest` covers the missing-file case.
