### PR TITLE
[NFC] [dev/core#6742] Correct return type comment for CRM_Core_Block::getContent()

### DIFF
--- a/CRM/Core/Block.php
+++ b/CRM/Core/Block.php
@@ -494,12 +494,12 @@ class CRM_Core_Block {
   }
 
   /**
-   * Given an id creates a subject/content array
+   * Given an id, creates a subject/content array, or NULL if there is an error
    *
    * @param int $id
    *   Id of the block.
    *
-   * @return array
+   * @return array|NULL
    */
   public static function getContent($id) {
     // return if upgrade mode


### PR DESCRIPTION
Overview
----------------------------------------
As part of investigation into [dev/core#6742](https://lab.civicrm.org/dev/core/-/work_items/6742), it was noticed that the return type comment / doc block for `CRM_Core_Block::getContent()` is incorrect.

Before
----------------------------------------
Comment suggests that the design contract is to return an `array`.

After
----------------------------------------
Comment corrected to reflect that the function could also return `NULL`.

Technical Details
----------------------------------------
Comments change only, no change to actual code.

Comments
----------------------------------------
N/A
