### PR TITLE
[dev/core#6742] Fix option 1: Handle NULL block in CRM_Core_Joomla::sidebarLeft()

### DIFF
--- a/CRM/Core/Joomla.php
+++ b/CRM/Core/Joomla.php
@@ -48,7 +48,10 @@ class CRM_Core_Joomla {
 
     $blocks = [];
     foreach ($blockIds as $id) {
-      $blocks[] = CRM_Core_Block::getContent($id);
+      $block = CRM_Core_Block::getContent($id);
+      if (isset($block)) {
+        $blocks[] = $block;
+      }
     }
 
     $template = CRM_Core_Smarty::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
Possible fix for [dev/core#6742](https://lab.civicrm.org/dev/core/-/work_items/6742), to remove unwanted PHP warnings due to accessing undefined array offset.

Before
----------------------------------------
`error_log` filled with repeated error messages:

```
[28-Aug-2026 06:26:39 Europe/London] PHP Warning:  Trying to access array offset on null in /home/csesorgu/public_html/media/civicrm/templates_c/en_US/74/06/2c/74062c422295b1f9701f795df7af01330e3a4636_0.file_blocks.tpl.php on line 38
[28-Aug-2026 06:26:39 Europe/London] PHP Warning:  Trying to access array offset on null in /home/csesorgu/public_html/media/civicrm/templates_c/en_US/74/06/2c/74062c422295b1f9701f795df7af01330e3a4636_0.file_blocks.tpl.php on line 39
[28-Aug-2026 06:26:39 Europe/London] PHP Warning:  Trying to access array offset on null in /home/csesorgu/public_html/media/civicrm/templates_c/en_US/74/06/2c/74062c422295b1f9701f795df7af01330e3a4636_0.file_blocks.tpl.php on line 41
[28-Aug-2026 06:26:39 Europe/London] PHP Warning:  Trying to access array offset on null in /home/csesorgu/public_html/media/civicrm/templates_c/en_US/74/06/2c/74062c422295b1f9701f795df7af01330e3a4636_0.file_blocks.tpl.php on line 44
```

After
----------------------------------------
Error messages go away.

Technical Details
----------------------------------------
This handles the fact that `CRM_Core_Block::getContent()` could return `NULL`. Currently this is not handled.

See associated #36713 for correction to doc block for `CRM_Core_Block::getContent()`.

Comments
----------------------------------------
The Joomla! sidebar function was removed under [dev/joomla#45](https://lab.civicrm.org/dev/joomla/-/work_items/45) so I believe this code can be removed entirely. See #36715 for this option.