### PR TITLE
Standardise isPaidEvent() on event registration forms

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -327,9 +327,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $params = ['id' => $this->getEventID()];
       CRM_Event_BAO_Event::retrieve($params, $this->_values['event']);
 
-      // check for is_monetary status
-      $isMonetary = $this->getEventValue('is_monetary');
-
       $this->checkValidEvent();
       // get the participant values, CRM-4320
       $this->_allowConfirmation = FALSE;
@@ -378,27 +375,15 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $this->setPayLaterLabel($isPayLater ? $this->_values['event']['pay_later_text'] : '');
       //check for various combinations for paylater, payment
       //process with paid event.
-      if ($isMonetary && (!$isPayLater || !empty($this->_values['event']['payment_processor']))) {
+      if ($this->isPaidEvent() && (!$isPayLater || !empty($this->_values['event']['payment_processor']))) {
         $this->_paymentProcessorIDs = explode(CRM_Core_DAO::VALUE_SEPARATOR, CRM_Utils_Array::value('payment_processor',
           $this->_values['event']
         ));
         $this->assignPaymentProcessor($isPayLater);
       }
 
-      $priceSetID = $this->getPriceSetID();
-      if ($priceSetID) {
+      if ($this->isPaidEvent()) {
         $this->initEventFee();
-
-        //fix for non-upgraded price sets.CRM-4256.
-        if (isset($this->_isPaidEvent)) {
-          $isPaidEvent = $this->_isPaidEvent;
-        }
-        else {
-          $isPaidEvent = $this->_values['event']['is_monetary'] ?? NULL;
-        }
-        if ($isPaidEvent && empty($this->getPriceFieldMetaData())) {
-          CRM_Core_Error::statusBounce(ts('Click <a href=\'%1\'>CiviEvent >> Manage Event >> Configure >> Event Fees</a> to configure the Fee Level(s) or Price Set for this event.', [1 => CRM_Utils_System::url('civicrm/event/manage/fee', 'reset=1&action=update&id=' . $this->_eventId)]), $this->getInfoPageUrl(), ts('No Fee Level(s) or Price Set is configured for this event.'));
-        }
       }
 
       // get the profile ids
@@ -437,7 +422,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
       $this->assignBillingType();
 
-      if ($this->_values['event']['is_monetary']) {
+      if ($this->isPaidEvent()) {
         CRM_Core_Payment_Form::setPaymentFieldsByProcessor($this, $this->_paymentProcessor);
       }
       $params = ['entity_id' => $this->_eventId, 'entity_table' => 'civicrm_event'];
@@ -463,7 +448,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       CRM_Utils_System::redirect($url);
     }
 
-    $this->assign('paidEvent', $this->getEventValue('is_monetary'));
+    $this->assign('paidEvent', $this->isPaidEvent());
     // we do not want to display recently viewed items on Registration pages
     $this->assign('displayRecent', FALSE);
 
@@ -769,7 +754,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $createPayment = TRUE;
     }
 
-    if ($createPayment && $this->_values['event']['is_monetary'] && !empty($this->_params['contributionID'])) {
+    if ($createPayment && $this->isPaidEvent() && !empty($this->_params['contributionID'])) {
       $paymentParams = [
         'participant_id' => $participant->id,
         'contribution_id' => $contribution->id,
@@ -1731,7 +1716,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $this->set('participantInfo', $participantInfo);
     }
 
-    if (!$this->getEventValue('is_monetary') || $this->getPaymentProcessorObject()->supports('noReturn')
+    if (!$this->isPaidEvent() || $this->getPaymentProcessorObject()->supports('noReturn')
     ) {
       // Send mail Confirmation/Receipt.
       $this->sendMails($params, $registerByID, $participantCount);
@@ -1885,10 +1870,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function buildAmount() {
+  protected function buildAmount(): void {
     $form = $this;
-    $priceSetID = $this->_priceSetId;
-    $required = TRUE;
     $discountId = NULL;
     $feeFields = $this->getPriceFieldMetaData();
 
@@ -1906,99 +1889,66 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     //reset required if participant is skipped.
     $button = substr($form->controller->getButtonName(), -4);
-    if ($required && $button === 'skip') {
-      $required = FALSE;
-    }
 
-    //build the priceset fields.
-    if ($priceSetID) {
+    // This is probably not required now - normally loaded from event ....
+    $form->add('hidden', 'priceSetId', $this->getPriceSetID());
 
-      // This is probably not required now - normally loaded from event ....
-      $form->add('hidden', 'priceSetId', $priceSetID);
+    // CRM-14492 Admin price fields should show up on event registration if user has 'administer CiviCRM' permissions
+    $adminFieldVisible = CRM_Core_Permission::check('administer CiviCRM data');
+    $hideAdminValues = !CRM_Core_Permission::check('edit event participants');
 
-      // CRM-14492 Admin price fields should show up on event registration if user has 'administer CiviCRM' permissions
-      $adminFieldVisible = CRM_Core_Permission::check('administer CiviCRM data');
-      $hideAdminValues = !CRM_Core_Permission::check('edit event participants');
+    foreach ($feeFields as $field) {
+      // public AND admin visibility fields are included for back-office registration and back-office change selections
+      if (($field['visibility'] ?? NULL) === 'public' ||
+        (($field['visibility'] ?? NULL) === 'admin' && $adminFieldVisible == TRUE)
+      ) {
+        $fieldId = $field['id'];
+        $elementName = 'price_' . $fieldId;
 
-      foreach ($feeFields as $field) {
-        // public AND admin visibility fields are included for back-office registration and back-office change selections
-        if (($field['visibility'] ?? NULL) === 'public' ||
-          (($field['visibility'] ?? NULL) === 'admin' && $adminFieldVisible == TRUE)
-        ) {
-          $fieldId = $field['id'];
-          $elementName = 'price_' . $fieldId;
+        $isRequire = $field['is_required'] ?? NULL;
+        if ($button === 'skip') {
+          $isRequire = FALSE;
+        }
 
-          $isRequire = $field['is_required'] ?? NULL;
-          if ($button === 'skip') {
-            $isRequire = FALSE;
-          }
+        //user might modified w/ hook.
+        $options = $field['options'] ?? NULL;
 
-          //user might modified w/ hook.
-          $options = $field['options'] ?? NULL;
+        if (!is_array($options)) {
+          continue;
+        }
+        if ($hideAdminValues) {
+          $publicVisibilityID = CRM_Price_BAO_PriceField::getVisibilityOptionID('public');
+          $adminVisibilityID = CRM_Price_BAO_PriceField::getVisibilityOptionID('admin');
 
-          if (!is_array($options)) {
-            continue;
-          }
-          if ($hideAdminValues) {
-            $publicVisibilityID = CRM_Price_BAO_PriceField::getVisibilityOptionID('public');
-            $adminVisibilityID = CRM_Price_BAO_PriceField::getVisibilityOptionID('admin');
-
-            foreach ($options as $key => $currentOption) {
-              $optionVisibility = $currentOption['visibility_id'] ?? $publicVisibilityID;
-              if ($optionVisibility == $adminVisibilityID) {
-                unset($options[$key]);
-              }
+          foreach ($options as $key => $currentOption) {
+            $optionVisibility = $currentOption['visibility_id'] ?? $publicVisibilityID;
+            if ($optionVisibility == $adminVisibilityID) {
+              unset($options[$key]);
             }
           }
-
-          $optionFullIds = $this->getOptionFullPriceFieldValues($field);
-
-          //soft suppress required rule when option is full.
-          if (!empty($optionFullIds) && (count($options) == count($optionFullIds))) {
-            $isRequire = FALSE;
-          }
-          foreach ($options as $option) {
-            $options[$option['id']]['is_full'] = $this->getIsOptionFull($option);
-          }
-          if (!empty($options)) {
-            //build the element.
-            CRM_Price_BAO_PriceField::addQuickFormElement($form,
-              $elementName,
-              $fieldId,
-              FALSE,
-              $isRequire,
-              NULL,
-              $options,
-              $optionFullIds
-            );
-          }
         }
-      }
-    }
-    else {
-      // Is this reachable?
-      // Noisy deprecation notice added in Sep 2023 (in previous code location).
-      CRM_Core_Error::deprecatedWarning('code believed to be unreachable');
-      $eventFeeBlockValues = $elements = $elementJS = [];
-      foreach ($feeFields as $fee) {
-        if (is_array($fee)) {
 
-          //CRM-7632, CRM-6201
-          $totalAmountJs = NULL;
-          $eventFeeBlockValues['amount_id_' . $fee['amount_id']] = $fee['value'];
-          $elements[$fee['amount_id']] = CRM_Utils_Money::format($fee['value']) . ' ' . $fee['label'];
-          $elementJS[$fee['amount_id']] = $totalAmountJs;
+        $optionFullIds = $this->getOptionFullPriceFieldValues($field);
+
+        //soft suppress required rule when option is full.
+        if (!empty($optionFullIds) && (count($options) == count($optionFullIds))) {
+          $isRequire = FALSE;
         }
-      }
-      $form->assign('eventFeeBlockValues', json_encode($eventFeeBlockValues));
-
-      $form->_defaults['amount'] = $form->_values['event']['default_fee_id'] ?? NULL;
-      $element = &$form->addRadio('amount', ts('Event Fee(s)'), $elements, [], '<br />', FALSE, $elementJS);
-      if (isset($form->_online) && $form->_online) {
-        $element->freeze();
-      }
-      if ($required) {
-        $form->addRule('amount', ts('Fee Level is a required field.'), 'required');
+        foreach ($options as $option) {
+          $options[$option['id']]['is_full'] = $this->getIsOptionFull($option);
+        }
+        if (!empty($options)) {
+          //build the element.
+          CRM_Price_BAO_PriceField::addQuickFormElement($form,
+            $elementName,
+            $fieldId,
+            FALSE,
+            $isRequire,
+            NULL,
+            $options,
+            $optionFullIds
+          );
+        }
       }
     }
   }
@@ -2035,6 +1985,18 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     );
 
     return $showPaymentOnConfirm;
+  }
+
+  /**
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  protected function isPaidEvent(): bool {
+    $isPaid = $this->getEventValue('is_monetary');
+    if ($isPaid && !$this->getPriceFieldMetaData()) {
+      CRM_Core_Error::statusBounce(ts('Click <a href=\'%1\'>CiviEvent >> Manage Event >> Configure >> Event Fees</a> to configure the Fee Level(s) or Price Set for this event.', [1 => CRM_Utils_System::url('civicrm/event/manage/fee', 'reset=1&action=update&id=' . $this->_eventId)]), $this->getInfoPageUrl(), ts('No Fee Level(s) or Price Set is configured for this event.'));
+    }
+    return $isPaid;
   }
 
 }

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -215,7 +215,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     $button = substr($this->controller->getButtonName(), -4);
 
-    if ($this->_values['event']['is_monetary']) {
+    if ($this->isPaidEvent()) {
       $this->buildAmount(TRUE, NULL, $this->_priceSetId);
     }
     $this->assign('priceSet', $this->_priceSet);
@@ -228,7 +228,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
     }
 
     //add buttons
-    if ($this->isLastParticipant(TRUE) && empty($this->_values['event']['is_monetary'])) {
+    if ($this->isLastParticipant(TRUE) && !$this->isPaidEvent()) {
       $this->submitOnce = TRUE;
     }
 
@@ -272,7 +272,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
       //lets allow to become a part of runtime waiting list, if primary selected pay later.
       $realPayLater = FALSE;
-      if (!empty($this->_values['event']['is_monetary']) && !empty($this->_values['event']['is_pay_later'])) {
+      if ($this->isPaidEvent() && !empty($this->_values['event']['is_pay_later'])) {
         $realPayLater = $this->_params[0]['is_pay_later'] ?? NULL;
       }
 
@@ -391,7 +391,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
         'isDefault' => TRUE,
       ];
       if ($this->isLastParticipant(TRUE)) {
-        if ($this->_values['event']['is_confirm_enabled'] || $this->_values['event']['is_monetary']) {
+        if ($this->_values['event']['is_confirm_enabled'] || $this->isPaidEvent()) {
           $buttonParams['name'] = ts('Review');
           $buttonParams['icon'] = 'fa-chevron-right';
         }
@@ -431,7 +431,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
     $button = substr($self->controller->getButtonName(), -4);
 
     $realPayLater = FALSE;
-    if (!empty($self->_values['event']['is_monetary']) && !empty($self->_values['event']['is_pay_later'])) {
+    if ($self->isPaidEvent() && !empty($self->_values['event']['is_pay_later'])) {
       $realPayLater = $self->_params[0]['is_pay_later'] ?? NULL;
     }
 
@@ -546,7 +546,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
     }
 
     if ($button != 'skip' &&
-      $self->_values['event']['is_monetary'] &&
+      $self->isPaidEvent() &&
       !isset($errors['_qf_default']) &&
       !$self->validatePaymentValues($self, $fields)
     ) {
@@ -703,18 +703,14 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       $config = CRM_Core_Config::singleton();
       $params['currencyID'] = $config->defaultCurrency;
 
-      if ($this->_values['event']['is_monetary']) {
+      if ($this->isPaidEvent()) {
 
         //added for discount
-        $discountId = CRM_Core_BAO_Discount::findSet($this->_eventId, 'civicrm_event');
+        $discountId = CRM_Core_BAO_Discount::findSet($this->getEventID(), 'civicrm_event');
         $params['amount_level'] = $this->getAmountLevel($params, $discountId);
         if (!empty($this->_values['discount'][$discountId])) {
           $params['discount_id'] = $discountId;
           $params['amount'] = $this->_values['discount'][$discountId][$params['amount']]['value'];
-        }
-        elseif (empty($params['priceSetId'])) {
-          CRM_Core_Error::deprecatedWarning('unreachable code, prices set always passed as hidden field for monetary events');
-          $params['amount'] = $this->_values['fee'][$params['amount']]['value'];
         }
         else {
           $lineItem = [];
@@ -770,7 +766,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
     if (
     // CRM-11182 - Optional confirmation screen
       !$this->_values['event']['is_confirm_enabled']
-      && !$this->_values['event']['is_monetary']
+      && !$this->isPaidEvent()
       && !empty($this->_params[0]['additional_participants'])
       && $this->isLastParticipant()
     ) {

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -90,7 +90,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $this->assign('hookDiscount', $this->_params[0]['discount'] ?? '');
     $this->preProcessExpress();
 
-    if ($this->_values['event']['is_monetary']) {
+    if ($this->isPaidEvent()) {
       $this->_params[0]['invoiceID'] = $this->get('invoiceID');
     }
     $this->assign('defaultRole', FALSE);
@@ -260,7 +260,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     // This use of the ts function uses the legacy interpolation of the button name to avoid translations having to be re-done.
     $this->assign('verifyText', !$this->_totalAmount ? ts('Click <strong>%1</strong> to complete your registration.', [1 => ts('Register')]) : $this->getPaymentProcessorObject()->getText('eventContinueText', []));
 
-    if ($this->_values['event']['is_monetary'] &&
+    if ($this->isPaidEvent() &&
       (isset($this->_params[0]['amount']) && is_numeric($this->_params[0]['amount'])) &&
       (!$this->_requireApproval || ($this->getEventValue('is_pay_later') && Civi::settings()->get('allow_price_selection_during_approval_registration')))
     ) {
@@ -391,7 +391,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/event/register', "reset=1&id={$form->getEventID()}", FALSE, NULL, FALSE, TRUE));
       }
     }
-    if ($form->getEventValue('is_monetary')) {
+    if ($form->isPaidEvent()) {
 
       if (!empty($form->_priceSetId) &&
         !$form->_requireApproval && !$form->_allowWaitlist
@@ -462,7 +462,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     $cancelledIds = $this->_additionalParticipantIds;
 
     $params = $this->_params;
-    if ($this->_values['event']['is_monetary']) {
+    if ($this->isPaidEvent()) {
       $this->set('finalAmount', $this->_amount);
     }
     $participantCount = [];
@@ -549,7 +549,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         //now becomes part of run time waiting list.
         $participantRecord['is_pay_later'] = FALSE;
       }
-      elseif ($this->_values['event']['is_monetary']) {
+      elseif ($this->isPaidEvent()) {
         // required only if paid event
         if (is_array($this->_paymentProcessor)) {
           $payment = $this->_paymentProcessor['object'];
@@ -648,7 +648,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       }
 
       // CRM-11182 - Confirmation page might not be monetary
-      if ($this->_values['event']['is_monetary']) {
+      if ($this->isPaidEvent()) {
         if (!$pending && !empty($participantRecord['is_primary']) &&
           !$this->_allowWaitlist && !$this->_requireApproval
         ) {
@@ -733,7 +733,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       }
 
       // do a transfer only if a monetary payment greater than 0
-      if ($this->_values['event']['is_monetary'] && $primaryParticipant) {
+      if ($this->isPaidEvent() && $primaryParticipant) {
         if ($payment && is_object($payment)) {
           //CRM 14512 provide line items of all participants to payment gateway
           $primaryContactId = $this->get('primaryContactId');
@@ -1019,7 +1019,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     // accidentally started working - causing https://lab.civicrm.org/dev/core/-/issues/5330 was
     // I can't see what changed...
     if (empty($params['email-Primary']) && (!empty($params['is_pay_later']) || empty($params['is_primary']) ||
-        !$form->_values['event']['is_monetary'] ||
+        !$form->isPaidEvent() ||
         $form->_allowWaitlist ||
         $form->_requireApproval
       ) && !empty($params["email-{$billingLocationTypeID}"])

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -418,7 +418,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $this->assign('allowGroupOnWaitlist', $allowGroupOnWaitlist);
     $this->assign('isAdditionalParticipants', $isAdditionalParticipants);
 
-    if ($this->_values['event']['is_monetary']) {
+    if ($this->isPaidEvent()) {
       // build amount only when needed, skip incase of event full and waitlisting is enabled
       // and few other conditions check preProcess()
       if (!$this->isSuppressPayment()) {
@@ -645,8 +645,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       }
     }
 
-    // @todo - can we remove the 'is_monetary' concept?
-    if ($form->_values['event']['is_monetary']) {
+    if ($form->isPaidEvent()) {
       if (empty($form->_requireApproval) && !empty($fields['amount']) && $fields['amount'] > 0 &&
         !isset($fields['payment_processor_id'])) {
         if (!$form->showPaymentOnConfirm) {
@@ -784,7 +783,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     $config = CRM_Core_Config::singleton();
     $params['currencyID'] = $config->defaultCurrency;
 
-    if ($this->_values['event']['is_monetary']) {
+    if ($this->isPaidEvent()) {
       // we first reset the confirm page so it accepts new values
       $this->controller->resetPage('Confirm');
 
@@ -794,13 +793,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       if (!empty($this->_values['discount'][$discountId])) {
         $params['discount_id'] = $discountId;
         $params['amount'] = $this->_values['discount'][$discountId][$params['amount']]['value'];
-      }
-      elseif (empty($params['priceSetId'])) {
-        // We would wind up here if waitlisting - in which case there should be no amount set.
-        if (!empty($params['amount'])) {
-          CRM_Core_Error::deprecatedWarning('unreachable code price set is always set here - passed as a hidden field although we could just load...');
-          $params['amount'] = $this->_values['fee'][$params['amount']]['value'];
-        }
       }
       else {
         $lineItem = [];
@@ -836,7 +828,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       // assumptions we are working to remove.
       $this->set('contributeMode', 'direct');
 
-      if ($this->_values['event']['is_monetary']) {
+      if ($this->isPaidEvent()) {
         $params['currencyID'] = $config->defaultCurrency;
         $params['invoiceID'] = $invoiceID;
       }

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -77,8 +77,8 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
       }
     }
     $this->assign('email', $email ?? NULL);
-    $this->assign('eventConfirmText', $this->getEventValue('is_monetary') ? $this->getPaymentProcessorObject()->getText('eventConfirmText', []) : '');
-    $this->assign('eventConfirmEmailText', ($email && $this->getEventValue('is_monetary')) ? $this->getPaymentProcessorObject()->getText('eventConfirmEmailText', ['email' => $email]) : '');
+    $this->assign('eventConfirmText', $this->isPaidEvent() ? $this->getPaymentProcessorObject()->getText('eventConfirmText', []) : '');
+    $this->assign('eventConfirmEmailText', ($email && $this->isPaidEvent()) ? $this->getPaymentProcessorObject()->getText('eventConfirmEmailText', ['email' => $email]) : '');
 
     $this->assignToTemplate();
 


### PR DESCRIPTION


Overview
----------------------------------------
Standardise isPaidEvent() on event registration forms

Before
----------------------------------------
Legacy functions allow for unclear possibility of an event with no price set - and there are large chunks of code with 'unreachable' deprecation notices that have been there for some time - in one place the only reachable code is in an always-try if.

In fact if the event is 'is_monetary' and it does not have a price set then there is a status bounce in preProcess - so this is never true. If it IS paid then priceSetId is always submitted as a hidden field.

After
----------------------------------------
This makes it explicit that a paid event must have the isMonetary flag AND a price set - allowing us to remove the deprecated code that allows for when there is not a price set

The statusBounce is moved into isPaid() so it is always obvious that it would be called


Technical Details
----------------------------------------
Note that this also removes an always-true IF that creates a lot of whitespace change

Comments
----------------------------------------
