### PR TITLE
Test api calls - be specific when calling apiv3 only functions

### DIFF
--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/PriceSetTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/PriceSetTest.php
@@ -64,7 +64,7 @@ class CRM_Contact_Form_Search_Custom_PriceSetTest extends TestCase implements He
   public function testRunSearch(): void {
     $this->eventCreatePaid();
     $contactID = $this->individualCreate();
-    $this->callAPISuccess('Order', 'create', [
+    $this->callApiV3Success('Order', 'create', [
       'total_amount' => 100,
       'currency' => 'USD',
       'contact_id' => $contactID,

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php
@@ -244,7 +244,7 @@ class CRM_Contact_BAO_GroupContactCacheTest extends CiviUnitTestCase {
     $this->callAPISuccess('Setting', 'create', ['smart_group_cache_refresh_mode' => 'opportunistic']);
     $this->callAPISuccess('Contact', 'create', ['id' => $this->ids['Contact']['dead1'], 'is_deceased' => 0]);
     $this->makeCacheStale($this->ids['Group'][0]);
-    $this->callAPISuccess('Job', 'group_cache_flush', []);
+    $this->callApiV3Success('Job', 'group_cache_flush', []);
     $this->assertCacheRefreshed($this->ids['Group'][0]);
   }
 

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -350,7 +350,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTestCase {
       message_header = {site.message_header}';
 
     $this->schedule->save();
-    $this->callAPISuccess('job', 'send_reminder', []);
+    $this->callApiV3Success('Job', 'send_reminder', []);
     $expected = [
       'first name = Alice',
       'receive_date = February 1st, 2015',

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -1035,7 +1035,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
 
     CRM_Utils_Time::setTime('2012-06-14 15:00:00');
     $mailUtil = new CiviMailUtils($this, TRUE);
-    $this->callAPISuccess('job', 'send_reminder');
+    $this->callApiV3Success('Job', 'send_reminder');
     $mailUtil->assertRecipients([['test-member@example.com']]);
     foreach ($mailUtil->getAllMessages('ezc') as $message) {
       /** @var ezcMail $message */
@@ -2502,7 +2502,7 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
   public function assertCronRuns(array $cronRuns): void {
     foreach ($cronRuns as $cronRun) {
       CRM_Utils_Time::setTime($cronRun['time']);
-      $this->callAPISuccess('job', 'send_reminder', []);
+      $this->callApiV3Success('Job', 'send_reminder', []);
       $this->mut->assertRecipients($cronRun['recipients']);
       if (array_key_exists('subjects', $cronRun)) {
         $this->mut->assertSubjects($cronRun['subjects']);

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -333,7 +333,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     $this->individualCreate(['first_name' => 'Bob', 'last_name' => 'Smith', 'street_address' => '123 Main St']);
     $this->individualCreate(['first_name' => 'Bob', 'email' => 'bob@example.org']);
     $this->individualCreate(['first_name' => 'Bob', 'email' => 'bob@example.org']);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', ['rule_group_id' => $this->ids['DedupeRuleGroup']['individual_general']])['values'];
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', ['rule_group_id' => $this->ids['DedupeRuleGroup']['individual_general']])['values'];
     $this->assertCount(2, $result['merged']);
     $queries = \Civi::$statics['CRM_Dedupe_FinderQueryOptimizer']['queries'];
     $this->assertEquals(['civicrm_email.email.8', 'civicrm_address.street_address.5', 'civicrm_contact.first_name.3'], array_keys($queries));

--- a/tests/phpunit/CRM/Mailing/MailingSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTest.php
@@ -202,7 +202,7 @@ class CRM_Mailing_MailingSystemTest extends CRM_Mailing_MailingSystemTestBase {
     // The following code is exactly the same as runMailingSuccess() except that we store the ID of the mailing.
     $mailing_1 = $this->callAPISuccess('Mailing', 'create', $mailingParams);
     $mut->assertRecipients([]);
-    $this->callAPISuccess('job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
+    $this->callApiV3Success('Job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
 
     $allMessages = $mut->getAllMessages('ezc');
     $this->assertCount(1, $allMessages);

--- a/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
+++ b/tests/phpunit/CRM/Mailing/MailingSystemTestBase.php
@@ -490,7 +490,7 @@ United States
     $mailingParams = array_merge($this->defaultParams, $params);
     $this->callAPISuccess('Mailing', 'create', $mailingParams);
     $this->_mut->assertRecipients([]);
-    $this->callAPISuccess('job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
+    $this->callApiV3Success('Job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
 
     $allMessages = $this->_mut->getAllMessages('ezc');
     // There are exactly two contacts produced by setUp().
@@ -527,7 +527,7 @@ United States
     ]);
     $this->callAPISuccess('Mailing', 'create', $mailingParams);
     $this->_mut->assertRecipients([]);
-    $this->callAPISuccess('job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
+    $this->callApiV3Success('Job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
     $queueItems = CRM_Core_DAO::executeQuery("SELECT * FROM civicrm_mailing_event_queue")->fetchAll();
     $this->assertCount(3, $queueItems);
     $hooks->reset();

--- a/tests/phpunit/CRM/Mailing/MailingUnsubscribeTest.php
+++ b/tests/phpunit/CRM/Mailing/MailingUnsubscribeTest.php
@@ -206,7 +206,7 @@ class CRM_Mailing_MailingUnsubscribeTest extends CiviUnitTestCase {
     ])['id'];
 
     // .. and send it
-    $ret = $this->callAPISuccess('job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
+    $ret = $this->callApiV3Success('Job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
 
     // Check the mailing has the right groupIds
     $mailinggroupIds = \Civi\Api4\MailingGroup::get(FALSE)

--- a/tests/phpunit/CRM/Mailing/MultilingualSystemTest.php
+++ b/tests/phpunit/CRM/Mailing/MultilingualSystemTest.php
@@ -153,7 +153,7 @@ class CRM_Mailing_MultilingualSystemTest extends CiviUnitTestCase {
     // The following code is exactly the same as runMailingSuccess() except that we store the ID of the mailing.
     $mailing_1 = $this->callAPISuccess('mailing', 'create', $mailingParams);
     $mut->assertRecipients([]);
-    $this->callAPISuccess('job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
+    $this->callApiV3Success('Job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
 
     $allMessages = $mut->getAllMessages('ezc');
     // There are exactly two contacts produced by setUp().
@@ -183,7 +183,7 @@ class CRM_Mailing_MultilingualSystemTest extends CiviUnitTestCase {
       'body_text'      => 'Please just {action.unsubscribeUrl}',
     ];
     $this->callAPISuccess('mailing', 'create', $mailingParams);
-    $_ = $this->callAPISuccess('job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
+    $_ = $this->callApiV3Success('Job', 'process_mailing', ['runInNonProductionEnvironment' => TRUE]);
 
     $allMessages = $mut->getAllMessages('ezc');
     // We should have 2+2 messages sent by the mail system now.

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -52,7 +52,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     ]);
 
     // Calling it 'Expiiiired' is OK.
-    $this->callAPISuccess('job', 'process_membership', []);
+    $this->callApiV3Success('Job', 'process_membership', []);
 
     $this->callAPISuccess('MembershipStatus', 'get', [
       'name' => 'Expired',
@@ -60,7 +60,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     ]);
 
     // Disabling 'Expired' is OK.
-    $this->callAPISuccess('job', 'process_membership', []);
+    $this->callApiV3Success('Job', 'process_membership', []);
 
     $this->callAPISuccess('MembershipStatus', 'get', [
       'name' => 'Expired',
@@ -68,7 +68,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     ]);
 
     // Deleting 'Expired' is OK.
-    $this->callAPISuccess('job', 'process_membership', []);
+    $this->callApiV3Success('Job', 'process_membership', []);
 
     // Put things back like normal
     $this->callAPISuccess('MembershipStatus', 'create', [

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -538,7 +538,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
 
     $createdMembershipID = $this->callAPISuccess('Membership', 'create', $params)['id'];
 
-    $this->callAPISuccess('Job', 'process_membership');
+    $this->callApiV3Success('Job', 'process_membership');
 
     $membershipAfterProcess = civicrm_api3('Membership', 'get', [
       'sequential' => 1,

--- a/tests/phpunit/CRM/SMS/ProviderTest.php
+++ b/tests/phpunit/CRM/SMS/ProviderTest.php
@@ -171,7 +171,7 @@ class CRM_SMS_ProviderTest extends CiviUnitTestCase {
     $mailing = $this->callAPISuccess('Mailing', 'create', $updateParams);
 
     // Process the SMS job.
-    $this->callAPISuccess('job', 'process_sms', ['runInNonProductionEnvironment' => TRUE]);
+    $this->callApiV3Success('job', 'process_sms', ['runInNonProductionEnvironment' => TRUE]);
 
     $activity = $this->callAPISuccess('activity', 'get', [
       'activity_type_id' => 'SMS delivery',

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorInboundTest.php
@@ -103,7 +103,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
     file_put_contents(__DIR__ . '/data/mail/' . $mail, $file_contents);
 
     // run the job
-    $this->callAPISuccess('job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
 
     // check that file was removed from mail dir
     $this->assertFalse(file_exists(__DIR__ . '/data/mail/' . $mail));
@@ -170,7 +170,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
       fclose($file);
     }
 
-    $this->callAPISuccess('Job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
     $activities = ActivityContact::get()
       ->addSelect('contact_id.email_primary.email', 'activity_id.activity_type_id:name', 'activity_id.subject')
       ->addWhere('contact_id.email_primary.email', 'IN', array_keys($badEmails))
@@ -186,7 +186,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
     $this->hookClass->setHook('civicrm_emailProcessor', [$this, 'hookImplForEmailProcessor']);
 
     copy(__DIR__ . '/data/inbound/test_hook.eml', __DIR__ . '/data/mail/test_hook.eml');
-    $this->callAPISuccess('Job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
 
     // The activity type should be changed.
     $activity = $this->callAPISuccess('Activity', 'getsingle', ['subject' => 'This is for hooks']);
@@ -197,7 +197,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
 
     // Now repeat with a different subject, and the type should be the default.
     copy(__DIR__ . '/data/inbound/test_non_cases_email.eml', __DIR__ . '/data/mail/test_non_cases_email.eml');
-    $this->callAPISuccess('Job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
     $activity = $this->callAPISuccess('Activity', 'getsingle', ['subject' => 'Love letter']);
     $this->assertEquals(
       CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound Email'),
@@ -260,7 +260,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
     $this->callAPISuccess('EntityTag', 'create', ['entity_table' => 'civicrm_contact', 'entity_id' => $catchall_id, 'tag_id' => $tag['id']]);
 
     copy(__DIR__ . '/data/inbound/test_hook.eml', __DIR__ . '/data/mail/test_hook.eml');
-    $this->callAPISuccess('Job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
 
     // The source contact should be our catchall not the original From contact.
     $activity = $this->callAPISuccess('Activity', 'getsingle', ['source_contact_id' => $catchall_id]);
@@ -282,7 +282,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
     $contact_id = $this->individualCreate(['email' => 'billing@paradox.biz']);
 
     copy(__DIR__ . '/data/inbound/test_hook.eml', __DIR__ . '/data/mail/test_hook.eml');
-    $this->callAPISuccess('Job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
 
     // The source contact should be our individual not the catchall
     $activity = $this->callAPISuccess('Activity', 'getsingle', ['source_contact_id' => $contact_id]);
@@ -308,7 +308,7 @@ class CRM_Utils_Mail_EmailProcessorInboundTest extends CiviUnitTestCase {
     $contact_id = $this->individualCreate(['email' => 'billing@paradox.biz']);
 
     copy(__DIR__ . '/data/inbound/test_hook.eml', __DIR__ . '/data/mail/test_hook.eml');
-    $this->callAPISuccess('Job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
 
     // The source contact should be the org not the individual
     $activity = $this->callAPISuccess('Activity', 'getsingle', ['source_contact_id' => $catchall_id]);

--- a/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
+++ b/tests/phpunit/CRM/Utils/Mail/EmailProcessorTest.php
@@ -76,7 +76,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
 
     copy(__DIR__ . '/data/bounces/bounce_no_verp.txt', __DIR__ . '/data/mail/bounce_no_verp.txt');
     $this->assertFileExists(__DIR__ . '/data/mail/bounce_no_verp.txt');
-    $this->callAPISuccess('job', 'fetch_bounces', []);
+    $this->callApiV3Success('Job', 'fetch_bounces', []);
     $this->assertFileDoesNotExist(__DIR__ . '/data/mail/bounce_no_verp.txt');
     $this->checkMailingBounces(1);
   }
@@ -89,7 +89,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_invalid_character.eml';
 
     copy(__DIR__ . '/data/bounces/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_bounces', ['is_create_activities' => TRUE]);
+    $this->callApiV3Success('Job', 'fetch_bounces', ['is_create_activities' => TRUE]);
     $this->assertFileDoesNotExist(__DIR__ . '/data/mail/' . $mail);
     $this->checkMailingBounces(1);
     $activity = $this->callAPISuccessGetSingle('Activity', ['activity_type_id' => 'Bounce']);
@@ -104,7 +104,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_utf8mb4_character.txt';
 
     copy(__DIR__ . '/data/bounces/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_bounces', []);
+    $this->callApiV3Success('Job', 'fetch_bounces', []);
     $this->assertFileDoesNotExist(__DIR__ . '/data/mail/' . $mail);
     $this->checkMailingBounces(1);
   }
@@ -119,7 +119,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_sample_message.eml';
 
     copy(__DIR__ . '/data/bounces/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_bounces', ['is_create_activities' => TRUE]);
+    $this->callApiV3Success('Job', 'fetch_bounces', ['is_create_activities' => TRUE]);
     $this->assertFileDoesNotExist(__DIR__ . '/data/mail/' . $mail);
     $this->checkMailingBounces(1);
     $this->callAPISuccessGetSingle('Activity', ['source_contact_id' => $this->contactID, 'activity_type_id' => 'Bounce']);
@@ -135,7 +135,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_nested_message.eml';
 
     copy(__DIR__ . '/data/bounces/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_bounces', []);
+    $this->callApiV3Success('Job', 'fetch_bounces', []);
     $this->assertFileDoesNotExist(__DIR__ . '/data/mail/' . $mail);
     $this->checkMailingBounces(1);
   }
@@ -164,7 +164,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
 
     copy(__DIR__ . '/data/bounces/bounce_no_verp.txt', __DIR__ . '/data/mail/bounce_no_verp.txt');
     $this->assertFileExists(__DIR__ . '/data/mail/bounce_no_verp.txt');
-    $this->callAPISuccess('job', 'fetch_bounces', []);
+    $this->callApiV3Success('Job', 'fetch_bounces', []);
     $this->assertFileDoesNotExist(__DIR__ . '/data/mail/bounce_no_verp.txt');
     $this->checkMailingBounces(1);
   }
@@ -199,7 +199,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
       ],
     ])['id'];
     $this->createMailing(['scheduled_date' => 'now', 'groups' => ['include' => [$groupID]]]);
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     $this->eventQueue = $this->callAPISuccess('MailingEventQueue', 'get', ['api.MailingEventQueue.create' => ['hash' => 'aaaaaaaaaaaaaaaz']]);
   }
 
@@ -228,7 +228,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_cases_email.eml';
 
     copy(__DIR__ . '/data/inbound/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
     $result = $this->callAPISuccess('Activity', 'get', [
       'sequential' => 1,
       'subject' => ['LIKE' => '%[case #214bf6d]%'],
@@ -244,7 +244,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_non_cases_email.eml';
 
     copy(__DIR__ . '/data/inbound/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
     $result = $this->callAPISuccess('Activity', 'get', [
       'sequential' => 1,
       'subject' => ['LIKE' => '%Love letter%'],
@@ -278,7 +278,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_non_cases_email.eml';
 
     copy(__DIR__ . '/data/inbound/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
     $result = $this->callAPISuccess('Contact', 'get', [
       'sequential' => 1,
       'email' => 'from@test.test',
@@ -325,7 +325,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_non_default_email.eml';
 
     copy(__DIR__ . '/data/inbound/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
     $activity = $this->callAPISuccessGetSingle('Activity', [
       'subject' => ['LIKE' => '%An email with two recipients%'],
       'return' => ['assignee_contact_id', 'target_contact_id', 'activity_type_id', 'status_id', 'source_contact_name', 'campaign_id'],
@@ -349,7 +349,7 @@ class CRM_Utils_Mail_EmailProcessorTest extends CiviUnitTestCase {
     $mail = 'test_non_default_email.eml';
 
     copy(__DIR__ . '/data/inbound/' . $mail, __DIR__ . '/data/mail/' . $mail);
-    $this->callAPISuccess('job', 'fetch_activities', []);
+    $this->callApiV3Success('Job', 'fetch_activities', []);
     $this->callAPISuccessGetCount('Contact', [
       'email' => 'bcc@test.test',
     ], 0);

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -644,7 +644,7 @@ contribution_recur.payment_instrument_id:name :Check
       'start_action_unit' => 'day',
       'body_html' => $tokenString,
     ]);
-    $this->callAPISuccess('Job', 'send_reminder', []);
+    $this->callApiV3Success('Job', 'send_reminder', []);
     $expected = $this->getExpectedMembershipTokenOutput();
     $mut->checkMailLog([$expected]);
 
@@ -860,7 +860,7 @@ my field';
       'smarty' => FALSE,
       'schema' => ['participantId'],
     ]);
-    $this->callAPISuccess('Job', 'send_reminder', []);
+    $this->callApiV3Success('Job', 'send_reminder', []);
     $expected = $this->getExpectedParticipantTokenOutput();
     $mut->checkMailLog([$expected]);
 
@@ -1027,7 +1027,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     $this->assertEquals(array_merge($tokens, $this->getDomainTokens()), $tokenProcessor->listTokens());
 
     $expectedEventString = $this->getExpectedEventTokenOutput();
-    $this->callAPISuccess('job', 'send_reminder', []);
+    $this->callApiV3Success('Job', 'send_reminder', []);
     $expectedParticipantString = $this->getExpectedParticipantTokenOutput();
     $toCheck = array_merge(explode("\n", $expectedEventString), explode("\n", $expectedParticipantString));
     $toCheck[] = $expectedEventString;
@@ -1050,7 +1050,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
     $mut = new CiviMailUtils($this);
     $this->setupParticipantScheduledReminder(FALSE);
 
-    $this->callAPISuccess('job', 'send_reminder', []);
+    $this->callApiV3Success('Job', 'send_reminder', []);
     $expected = $this->getExpectedEventTokenOutput();
     // Checking these individually is easier to decipher discrepancies
     // but we also want to check in entirety.

--- a/tests/phpunit/Civi/API/Subscriber/TransactionSubscriberTest.php
+++ b/tests/phpunit/Civi/API/Subscriber/TransactionSubscriberTest.php
@@ -108,7 +108,7 @@ class TransactionSubscriberTest extends \CiviUnitTestCase {
   }
 
   public function testForceRollback(): void {
-    $result = $this->callAPISuccess('contact', 'create', [
+    $result = $this->callAPIV3Success('contact', 'create', [
       'contact_type' => 'Individual',
       'first_name' => 'Me',
       'last_name' => 'Myself',

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTestCase.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTestCase.php
@@ -291,7 +291,7 @@ abstract class AbstractMappingTestCase extends \CiviUnitTestCase {
     $actualMessages = [];
     foreach ($this->cronTimes() as $time) {
       \CRM_Utils_Time::setTime($time);
-      $this->callAPISuccess('job', 'send_reminder', []);
+      $this->callApiV3Success('Job', 'send_reminder', []);
       foreach ($this->mut->getAllMessages('ezc') as $message) {
         /** @var \ezcMail $message */
         $simpleMessage = [

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -1980,7 +1980,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       ],
     ], $conflicts);
 
-    $this->callAPISuccess('Job', 'process_batch_merge');
+    $this->callApiV3Success('Job', 'process_batch_merge');
     $defaultRuleGroupID = $this->callAPISuccessGetValue('RuleGroup', [
       'contact_type' => 'Individual',
       'used' => 'Unsupervised',
@@ -3997,7 +3997,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     // wind up being should be [1]
     $this->callAPISuccess('Contact', 'merge', ['to_remove_id' => $contactIDs[0], 'to_keep_id' => $contactIDs[3]]);
 
-    $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $this->callApiV3Success('Job', 'process_batch_merge', []);
     foreach ($contactIDs as $contactID) {
       if ($contactID === $contactIDs[1]) {
         continue;

--- a/tests/phpunit/api/v3/JobProcessMailingTest.php
+++ b/tests/phpunit/api/v3/JobProcessMailingTest.php
@@ -94,7 +94,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     ]);
     $mailing = $this->callAPISuccess('Mailing', 'create', $this->_params);
     $this->_mut->assertRecipients([]);
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     $mailing = $this->callAPISuccessGetSingle('Mailing', ['id' => $mailing['id'], 'version' => 4]);
     $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($mailing['start_date'])));
     $this->assertNull($mailing['end_date']);
@@ -115,13 +115,13 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       'Content-Transfer-Encoding: 8bit',
     ]);
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
-    $this->callAPISuccess('Job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
-    $this->callAPISuccess('Job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
-    $this->callAPISuccess('Job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
-    $this->callAPISuccess('Job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     $updatedMailing = $this->callAPISuccessGetSingle('Mailing', ['id' => $mailing['id'], 'version' => 4]);
     $this->assertEquals($mailing['start_date'], $updatedMailing['start_date']);
     $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($updatedMailing['end_date'])));
@@ -135,7 +135,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     $this->createContactsInGroup(2, $this->_groupID);
     $this->callAPISuccess('Mailing', 'create', $this->_params);
     $this->callAPISuccess('Contact', 'delete', ['id' => $this->callAPISuccessGetValue('GroupContact', ['return' => 'contact_id', 'options' => ['limit' => 1, 'sort' => 'id DESC']])]);
-    $this->callAPISuccess('job', 'process_mailing');
+    $this->callApiV3Success('Job', 'process_mailing');
     $this->_mut->assertRecipients($this->getRecipients(1, 1));
   }
 
@@ -157,7 +157,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     $this->assertEquals(3, $this->callAPISuccess('MailingRecipients', 'get', ['mailing_id' => $mailing['id']])['count']);
     $this->_mut->assertRecipients([]);
     $this->callAPISuccess('Contact', 'create', ['id' => $contactID, 'is_deceased' => 1, 'contact_type' => 'Individual']);
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     // Check that the deceased contact is not found in the mailing.
     $this->_mut->assertRecipients($this->getRecipients(1, 2));
 
@@ -188,7 +188,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     ]);
     $mailing = $this->callAPISuccess('mailing', 'create', $this->_params);
     $this->assertEquals(2, $this->callAPISuccess('MailingRecipients', 'get', ['mailing_id' => $mailing['id']])['count']);
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     $this->_mut->assertRecipients([['mail1@example.org'], ['mail2@example.org']]);
     // Don't leave data lying around for other tests to screw up on.
     $this->callAPISuccess('Email', 'delete', ['id' => $email1['id']]);
@@ -217,7 +217,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     $this->assertEquals('Paused', $mailing['status']);
 
     //Verify if Paused mailing isn't considered in process_mailing job.
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     //Check if mail log is empty.
     $this->_mut->assertMailLogEmpty();
     $jobs = $this->callAPISuccess('mailing_job', 'get', ['mailing_id' => $result['id']]);
@@ -229,7 +229,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     $this->assertEquals('Scheduled', $jobs['values'][$jobs['id']]['status']);
 
     //Execute the job and it should send the mailing to the recipients now.
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     $this->_mut->assertRecipients($this->getRecipients(1, 2));
     // Ensure that loading the report produces no errors.
     $report = CRM_Mailing_BAO_Mailing::report($result['id']);
@@ -306,7 +306,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
       'environment' => 'Production',
     ];
     $this->callAPISuccess('Setting', 'create', $params);
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     $this->_mut->assertRecipients($this->getRecipients(1, 2));
   }
 
@@ -550,7 +550,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
 
     $this->createContactsInGroup(6, $this->_groupID);
     $mailing = $this->callAPISuccess('mailing', 'create', $this->_params + ['scheduled_id' => $loggedInUserId]);
-    $this->callAPISuccess('Job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     $bulkEmailActivity = $this->callAPISuccess('Activity', 'getsingle', [
       'source_record_id' => $mailing['id'],
       'activity_type_id' => 'Bulk Email',
@@ -563,7 +563,7 @@ class api_v3_JobProcessMailingTest extends CiviUnitTestCase {
     // to get it to process the other batches.
     CRM_Mailing_BAO_MailingJob::$mailsProcessed = 0;
 
-    $this->callAPISuccess('job', 'process_mailing', []);
+    $this->callApiV3Success('Job', 'process_mailing', []);
     $bulkEmailActivity = $this->callAPISuccess('Activity', 'getsingle', [
       'source_record_id' => $mailing['id'],
       'activity_type_id' => 'Bulk Email',

--- a/tests/phpunit/api/v3/JobProcessMembershipTest.php
+++ b/tests/phpunit/api/v3/JobProcessMembershipTest.php
@@ -183,7 +183,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testByDefaultTestsAreExcluded(): void {
     $testId = $this->createTestMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', []);
+    $this->callApiV3Success('Job', 'process_membership', []);
 
     $this->assertEquals('Grace', $this->getMembershipStatus($testId));
   }
@@ -193,7 +193,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
    */
   public function testByDefaultInactiveAreExcluded(): void {
     $oldId = $this->createOldMembershipThatShouldBeCurrent();
-    $this->callAPISuccess('job', 'process_membership', []);
+    $this->callApiV3Success('Job', 'process_membership', []);
     $this->assertEquals('Grace', $this->getMembershipStatus($oldId));
   }
 
@@ -202,7 +202,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
    */
   public function testByDefaultGraceIsConsidered(): void {
     $graceID = $this->createGraceMembershipThatShouldBeCurrent();
-    $this->callAPISuccess('job', 'process_membership', []);
+    $this->callApiV3Success('Job', 'process_membership', []);
     $this->assertEquals('Current', $this->getMembershipStatus($graceID));
   }
 
@@ -214,7 +214,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
    */
   public function testByDefaultPendingIsExcluded(): void {
     $pendingID = $this->createPendingMembershipThatShouldBeCurrent();
-    $this->callAPISuccess('job', 'process_membership', []);
+    $this->callApiV3Success('Job', 'process_membership', []);
     $this->assertEquals('Pending', $this->getMembershipStatus($pendingID));
   }
 
@@ -223,7 +223,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
    */
   public function testByDefaultDeceasedIsExcluded(): void {
     $deceasedID = $this->createDeceasedMembershipThatShouldBeExpired();
-    $this->callAPISuccess('job', 'process_membership', []);
+    $this->callApiV3Success('Job', 'process_membership', []);
     $this->assertEquals('Deceased', $this->getMembershipStatus($deceasedID));
   }
 
@@ -237,7 +237,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingTestMembershipsExcludesPending(): void {
     $pendingId = $this->createPendingMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_test_memberships' => FALSE,
     ]);
 
@@ -251,7 +251,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingTestMembershipsConsidersGrace(): void {
     $graceId = $this->createGraceMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_test_memberships' => FALSE,
     ]);
 
@@ -265,7 +265,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingTestMembershipsIgnoresInactive(): void {
     $oldId = $this->createOldMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_test_memberships' => FALSE,
     ]);
 
@@ -279,7 +279,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingTestMembershipsActuallyIncludesThem(): void {
     $testId = $this->createTestMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_test_memberships' => FALSE,
     ]);
 
@@ -293,7 +293,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingTestMembershipsStillIgnoresDeceased(): void {
     $deceasedId = $this->createDeceasedMembershipThatShouldBeExpired();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_test_memberships' => FALSE,
     ]);
 
@@ -310,7 +310,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingInactiveMembershipTypesStillExcludesPending(): void {
     $pendingId = $this->createPendingMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'only_active_membership_types' => FALSE,
     ]);
 
@@ -324,7 +324,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingInactiveMembershipTypesConsidersGrace(): void {
     $graceId = $this->createGraceMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'only_active_membership_types' => FALSE,
     ]);
 
@@ -338,7 +338,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingInactiveMembershipTypesConsidersInactive(): void {
     $oldId = $this->createOldMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'only_active_membership_types' => FALSE,
     ]);
 
@@ -352,7 +352,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testIncludingInactiveMembershipTypesStillIgnoresTests(): void {
     $testId = $this->createTestMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'only_active_membership_types' => FALSE,
     ]);
 
@@ -366,7 +366,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testMembershipTypeDeceasedIsExcluded(): void {
     $deceasedId = $this->createDeceasedMembershipThatShouldBeExpired();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'only_active_membership_types' => FALSE,
     ]);
 
@@ -380,7 +380,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testSpecifyingTheStatusIdsToExcludeStillExcludesDeceased(): void {
     $deceasedId = $this->createDeceasedMembershipThatShouldBeExpired();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_membership_status_ids' => [
         CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Cancelled'),
       ],
@@ -396,7 +396,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testSpecifyingTheStatusIdsToExcludeStillExcludesTests(): void {
     $testId = $this->createTestMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_membership_status_ids' => [
         CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Cancelled'),
       ],
@@ -412,7 +412,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testSpecifyingTheStatusIdsToExcludeStillExcludesInactive(): void {
     $oldId = $this->createOldMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_membership_status_ids' => [
         CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Cancelled'),
       ],
@@ -428,7 +428,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testSpecifyingTheStatusIdsToExcludeGraceIsIncludedByDefault(): void {
     $graceId = $this->createGraceMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_membership_status_ids' => [
         CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Cancelled'),
       ],
@@ -445,7 +445,7 @@ class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
   public function testSpecifyingTheStatusIdsToExcludePendingIsExcludedByDefault(): void {
     $pendingId = $this->createPendingMembershipThatShouldBeCurrent();
 
-    $this->callAPISuccess('job', 'process_membership', [
+    $this->callApiV3Success('Job', 'process_membership', [
       'exclude_membership_status_ids' => [
         CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Cancelled'),
       ],

--- a/tests/phpunit/api/v3/JobTestCustomDataTest.php
+++ b/tests/phpunit/api/v3/JobTestCustomDataTest.php
@@ -141,7 +141,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $contact2Params = is_array($dataSet['contacts'][1]) ? [$customFieldLabel => $dataSet['contacts'][1]] : [];
     $contactID = $this->individualCreate($contact1Params);
     $this->individualCreate($contact2Params);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', ['mode' => $dataSet['mode']]);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', ['mode' => $dataSet['mode']]);
     $this->assertCount($dataSet['merged'], $result['values']['merged']);
     $this->assertCount($dataSet['skipped'], $result['values']['skipped']);
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
@@ -217,7 +217,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customFieldID;
     $contactID = $this->individualCreate();
     $this->individualCreate([$customFieldLabel => '2012-12-03']);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(1, count($result['values']['merged']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
     $this->assertEquals('2012-12-03 00:00:00', $contact[$customFieldLabel]);
@@ -237,7 +237,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customFieldID;
     $contactID = $this->individualCreate();
     $this->individualCreate([$customFieldLabel => '2012-11-03']);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(1, count($result['values']['merged']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
     $this->assertEquals('2012-11-03 00:00:00', $contact[$customFieldLabel]);
@@ -250,7 +250,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customFieldID;
     $contactID = $this->individualCreate([$customFieldLabel => '2012-11-03']);
     $this->individualCreate([$customFieldLabel => '2013-11-03']);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(0, count($result['values']['merged']));
     $this->assertEquals(1, count($result['values']['skipped']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
@@ -264,7 +264,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customFieldID;
     $contactID = $this->individualCreate([$customFieldLabel => '2012-11-03']);
     $this->individualCreate([$customFieldLabel => '2012-11-03']);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(1, count($result['values']['merged']));
     $this->assertEquals(0, count($result['values']['skipped']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
@@ -278,7 +278,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customIntFieldID;
     $contactID = $this->individualCreate([]);
     $this->individualCreate([$customFieldLabel => 20]);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(1, count($result['values']['merged']));
     $this->assertEquals(0, count($result['values']['skipped']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
@@ -292,7 +292,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customIntFieldID;
     $contactID = $this->individualCreate([$customFieldLabel => 20]);
     $this->individualCreate([$customFieldLabel => 1]);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(0, count($result['values']['merged']));
     $this->assertEquals(1, count($result['values']['skipped']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
@@ -306,7 +306,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customIntFieldID;
     $contactID = $this->individualCreate([$customFieldLabel => 0]);
     $this->individualCreate([$customFieldLabel => 20]);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(0, count($result['values']['merged']));
     $this->assertEquals(1, count($result['values']['skipped']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
@@ -325,7 +325,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customFieldID;
     $contactID = $this->individualCreate([$customFieldLabel => '2012-11-03']);
     $this->individualCreate([$customFieldLabel => '2013-11-03']);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', ['check_permissions' => 0]);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', ['check_permissions' => 0]);
     $this->assertEquals(0, count($result['values']['merged']));
     $this->assertEquals(1, count($result['values']['skipped']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
@@ -344,7 +344,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customFieldID;
     $contactID = $this->individualCreate();
     $this->individualCreate([$customFieldLabel => '2013-11-03']);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', ['check_permissions' => 0]);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', ['check_permissions' => 0]);
     $this->assertEquals(1, count($result['values']['merged']));
     $this->assertEquals(0, count($result['values']['skipped']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', ['id' => $contactID, 'return' => $customFieldLabel]);
@@ -363,7 +363,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
     $customFieldLabel = 'custom_' . $this->customIntFieldID;
     $contactID = $this->individualCreate(['custom_' . $this->customBoolFieldID => 1]);
     $this->individualCreate([$customFieldLabel => 1, 'custom_' . $this->customBoolFieldID => 1]);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', ['check_permissions' => 0]);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', ['check_permissions' => 0]);
     $this->assertEquals(1, count($result['values']['merged']));
     $this->assertEquals(0, count($result['values']['skipped']));
     $contact = $this->callAPISuccess('Contact', 'getsingle', [
@@ -380,7 +380,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
   public function testBatchMergeCustomFieldConflicts(): void {
     $this->individualCreate(['custom_' . $this->customBoolFieldID => 0]);
     $this->individualCreate(['custom_' . $this->customBoolFieldID => 1]);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(0, count($result['values']['merged']));
     $this->assertEquals(1, count($result['values']['skipped']));
   }
@@ -391,7 +391,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
   public function testBatchMergeCustomFieldConflictsReverse(): void {
     $this->individualCreate(['custom_' . $this->customBoolFieldID => 1]);
     $this->individualCreate(['custom_' . $this->customBoolFieldID => 0]);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertEquals(0, count($result['values']['merged']));
     $this->assertEquals(1, count($result['values']['skipped']));
   }
@@ -404,7 +404,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
   public function testBatchMergeCustomFieldNoConflictsOneBlank(): void {
     $this->individualCreate(['custom_' . $this->customBoolFieldID => 1]);
     $this->individualCreate();
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertCount(1, $result['values']['merged']);
     $this->assertCount(0, $result['values']['skipped']);
   }
@@ -417,7 +417,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
   public function testBatchMergeCustomFieldNoConflictsOneBlankReverse(): void {
     $contactID = $this->individualCreate();
     $this->individualCreate(['custom_' . $this->customBoolFieldID => 1]);
-    $result = $this->callAPISuccess('Job', 'process_batch_merge', []);
+    $result = $this->callApiV3Success('Job', 'process_batch_merge', []);
     $this->assertCount(1, $result['values']['merged']);
     $this->assertCount(0, $result['values']['skipped']);
     $this->assertEquals(1, $this->callAPISuccessGetValue('Contact', ['id' => $contactID, 'return' => 'custom_' . $this->customBoolFieldID]));

--- a/tests/phpunit/api/v3/PledgePaymentTest.php
+++ b/tests/phpunit/api/v3/PledgePaymentTest.php
@@ -83,7 +83,7 @@ class api_v3_PledgePaymentTest extends CiviUnitTestCase {
     $this->assertEquals('Pending Label**', $checkStatus['pledge_status']);
 
     //Execute process_pledge job log.
-    $result = $this->callAPISuccess('Job', 'process_pledge', []);
+    $result = $this->callApiV3Success('Job', 'process_pledge', []);
     $this->assertEquals("Checking if status update is needed for Pledge Id: $this->_pledgeID (current status is Pending)\n\r- status updated to: Overdue\n\r1 records updated.", $result['values']);
 
     //Status should be 'Overdue' after processing.


### PR DESCRIPTION
Overview
----------------------------------------
Test api calls - be specific when calling apiv3 only functions

Before
----------------------------------------
We have an apiv3 specific function for when it matters but in these cases it was relying on the class property

After
----------------------------------------
Explicit - also some trait removals when the trait is not actually used

Technical Details
----------------------------------------


Comments
----------------------------------------

