### PR TITLE
Reduce reliance from ContactTest trait on apiv3 trait

### DIFF
--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -3,6 +3,9 @@
 namespace Civi\Test;
 
 use Civi\Api4\Contact;
+use Civi\Api4\Group;
+use Civi\Api4\GroupContact;
+use Civi\Api4\UFMatch;
 
 /**
  * Class ContactTestTrait
@@ -10,9 +13,9 @@ use Civi\Api4\Contact;
  * @package Civi\Test
  *
  * This trait defines a number of helper functions for managing
- * test contacts. Generally, it depends on having access to the
- * API test functions ($this->callAPISuccess()) and to the
- * standard PHPUnit assertions ($this->assertEquals). It should
+ * test contacts. Historicallly, it depends on having access to the
+ * API test functions ($this->callAPISuccess()) but that is now the exception.
+ * It requires the standard PHPUnit assertions ($this->assertEquals). It should
  * not impose any other requirements for the downstream consumer class.
  */
 trait ContactTestTrait {
@@ -42,15 +45,25 @@ trait ContactTestTrait {
       'first_name' => 'Logged In',
       'last_name' => 'User ' . mt_rand(),
       'contact_type' => 'Individual',
-      'domain_id' => \CRM_Core_Config::domainID(),
     ];
     $contactID = $this->individualCreate($params, 'logged_in');
-    $this->callAPISuccess('UFMatch', 'get', ['uf_id' => 6, 'api.UFMatch.delete' => []]);
-    $this->callAPISuccess('UFMatch', 'create', [
-      'contact_id' => $contactID,
-      'uf_name' => 'superman',
-      'uf_id' => 6,
-    ]);
+    try {
+      $existingMatchIDs = (array) UFMatch::get(FALSE)
+        ->addWhere('uf_id', '=', 6)
+        ->execute()
+        ->column('id');
+      if ($existingMatchIDs) {
+        UFMatch::delete(FALSE)->addWhere('id', 'IN', $existingMatchIDs)->execute();
+      }
+      UFMatch::create(FALSE)->setValues([
+        'contact_id' => $contactID,
+        'uf_name' => 'superman',
+        'uf_id' => 6,
+      ])->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->fail($e->getMessage());
+    }
 
     $session = \CRM_Core_Session::singleton();
     $session->set('userID', $contactID);
@@ -234,10 +247,15 @@ trait ContactTestTrait {
     $domain = new \CRM_Core_BAO_Domain();
     $domain->contact_id = $contactID;
     if (!$domain->find(TRUE)) {
-      $this->callAPISuccess('contact', 'delete', [
-        'id' => $contactID,
-        'skip_undelete' => 1,
-      ]);
+      try {
+        Contact::delete(FALSE)
+          ->addWhere('id', '=', $contactID)
+          ->setUseTrash(FALSE)
+          ->execute();
+      }
+      catch (\CRM_Core_Exception $e) {
+        $this->fail($e->getMessage());
+      }
     }
   }
 
@@ -275,11 +293,12 @@ trait ContactTestTrait {
    * @param int $gid
    */
   public function groupDelete($gid) {
-    $params = [
-      'id' => $gid,
-    ];
-
-    $this->callAPISuccess('Group', 'delete', $params);
+    try {
+      Group::delete(FALSE)->addWhere('id', '=', $gid)->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->fail($e->getMessage());
+    }
   }
 
   /**
@@ -294,20 +313,22 @@ trait ContactTestTrait {
    * @return int
    *   groupId of created group
    */
-  public function groupContactCreate($groupID, $totalCount = 10, $random = FALSE) {
-    $params = ['group_id' => $groupID];
+  public function groupContactCreate($groupID, $totalCount = 10, $random = FALSE): array {
+    $records = [];
     for ($i = 1; $i <= $totalCount; $i++) {
       $contactID = $this->individualCreate([], 0, $random);
-      if ($i == 1) {
-        $params += ['contact_id' => $contactID];
-      }
-      else {
-        $params += ["contact_id.$i" => $contactID];
-      }
+      $records[] = ['group_id' => $groupID, 'contact_id' => $contactID];
     }
-    $result = $this->callAPISuccess('GroupContact', 'create', $params);
-
-    return $result;
+    try {
+      GroupContact::save(FALSE)->setRecords($records)->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->fail($e->getMessage());
+    }
+    // These are all fresh contacts being added for the first time, so every
+    // record is a genuine addition - matches the v3 GroupContact.create
+    // 'added' count that some callers still check.
+    return ['added' => $totalCount];
   }
 
 }

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -198,6 +198,17 @@ trait ContactTestTrait {
       }
     }
     $nonV4Fields = array_diff_key($params, $this->apiV4Fields[$params['contact_type']]);
+    foreach ($nonV4Fields as $key => $value) {
+      if (str_contains($key, '_primary.') || str_contains($key, '_billing.')) {
+        unset($nonV4Fields[$key]);
+      }
+      // PseudoConstant syntax (eg 'gender_id:name') is valid apiv4 for any
+      // field that has options, so check against the base field name too.
+      [$fieldName] = explode(':', $key, 2);
+      if ($fieldName !== $key && isset($this->apiV4Fields[$params['contact_type']][$fieldName])) {
+        unset($nonV4Fields[$key]);
+      }
+    }
     if (!empty($nonV4Fields)) {
       // Let's fall back to the earlier assumption of apiv3
       $defaultVersion = 3;

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
@@ -21,21 +21,21 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
    *  Test case for contact search: CRM-6706, CRM-6586 Parent Group search should return contacts from child groups too.
    */
   public function testContactSearchByParentGroup(): void {
-    $parentGroup = $this->callAPISuccess('Group', 'create', [
+    $parentGroup = $this->createTestEntity('Group', [
       'title' => 'Parent Group',
       'description' => 'Parent Group',
       'visibility' => 'User and User Admin Only',
       'is_active' => 1,
-    ]);
+    ], 'parent');
 
     // create a child group
-    $childGroup = $this->callAPISuccess('Group', 'create', [
+    $childGroup = $this->createTestEntity('Group', [
       'title' => 'Child Group',
       'description' => 'Child Group',
       'visibility' => 'User and User Admin Only',
       'parents' => $parentGroup['id'],
       'is_active' => 1,
-    ]);
+    ], 'child');
 
     // create smart group based on saved criteria Gender = Male
     $batch = $this->callAPISuccess('SavedSearch', 'create', [
@@ -43,7 +43,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     ]);
     // Create contact with Gender - Male
     $childSmartGroupContact = $this->individualCreate([
-      'gender_id' => 'Male',
+      'gender_id:name' => 'Male',
       'first_name' => 'C',
     ], 1);
     // then create smart group
@@ -60,20 +60,20 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     $parentContactParams = [
       'first_name' => 'Parent1 First name',
       'last_name' => 'Parent1 Last name',
-      'group' => [$parentGroup['id'] => 1],
     ];
     $parentContact = $this->individualCreate($parentContactParams);
+    $this->createTestEntity('GroupContact', ['group_id' => $parentGroup['id'], 'contact_id' => $parentContact, 'status' => 'Added']);
 
     // Create a contact within child group.
     $childContactParams = [
       'first_name' => 'Child1 First name',
       'last_name' => 'Child2 Last name',
-      'group' => [$childGroup['id'] => 1],
     ];
     $childContact = $this->individualCreate($childContactParams);
+    $this->createTestEntity('GroupContact', ['group_id' => $childGroup['id'], 'contact_id' => $childContact, 'status' => 'Added']);
 
     // Check if searching by parent group  returns both parent and child group contacts.
-    $contacts = $this->callAPISuccess('Contact', 'get', [
+    $contacts = $this->callAPIV3Success('Contact', 'get', [
       'group' => $parentGroup['id'],
     ])['values'];
     $validContactIds = [$parentContact, $childContact];
@@ -85,7 +85,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     $this->assertEquals([], array_diff($validContactIds, $resultContactIds), 'Check that the difference between two arrays should be blank array');
 
     // Check if searching by child group returns just child group contacts.
-    $contacts = $this->callAPISuccess('Contact', 'get', [
+    $contacts = $this->callAPIV3Success('Contact', 'get', [
       'group' => $childGroup['id'],
     ])['values'];
     $validChildContactIds = [$childContact];
@@ -97,7 +97,7 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     $this->assertEquals([], array_diff($validChildContactIds, $resultChildContactIds), 'Check that the difference between two arrays should be blank array');
 
     // Check if searching by smart child group returns just smart child group contacts
-    $contacts = $this->callAPISuccess('Contact', 'get', [
+    $contacts = $this->callAPIV3Success('Contact', 'get', [
       'group' => $childSmartGroup['id'],
     ])['values'];
     $validChildContactIds = [$childSmartGroupContact];
@@ -107,11 +107,6 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     }
     $this->assertCount(1, $resultChildContactIds, 'Check the count of returned values');
     $this->assertEquals([], array_diff($validChildContactIds, $resultChildContactIds), 'Check that the difference between two arrays should be blank array');
-
-    //cleanup
-    $this->callAPISuccess('Contact', 'delete', ['id' => $parentContact]);
-    $this->callAPISuccess('Contact', 'delete', ['id' => $childContact]);
-    $this->callAPISuccess('Contact', 'delete', ['id' => $childSmartGroupContact]);
   }
 
   /**
@@ -131,23 +126,23 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
 
     // Create contact with Gender - Male
     $contact1 = $this->individualCreate([
-      'gender_id' => 'Male',
+      'gender_id:name' => 'Male',
       'first_name' => 'A',
     ]);
 
     // Create contact with Gender - Male and in regular group
     $contact2 = $this->individualCreate([
-      'group' => [$regularGroup['id'] => 1],
-      'gender_id' => 'Male',
+      'gender_id:name' => 'Male',
       'first_name' => 'B',
     ], 1);
+    $this->createTestEntity('GroupContact', ['group_id' => $regularGroup['id'], 'contact_id' => $contact2, 'status' => 'Added']);
 
     // Create contact with Gender - Female and in regular group
     $contact3 = $this->individualCreate([
-      'group' => [$regularGroup['id'] => 1],
-      'gender_id' => 'Female',
+      'gender_id:name' => 'Female',
       'first_name' => 'C',
     ], 1);
+    $this->createTestEntity('GroupContact', ['group_id' => $regularGroup['id'], 'contact_id' => $contact3, 'status' => 'Added']);
 
     // create smart group based on saved criteria Gender = Male
     $batch = $this->callAPISuccess('SavedSearch', 'create', [

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Api4\Email;
 use Civi\Api4\OptionValue;
 
 /**
@@ -463,36 +464,39 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
    * Set up some data for us to do testing on.
    */
   public function setUpContactExportData(): void {
-    $this->contactIDs[] = $contactA = $this->individualCreate(['gender_id' => 'Female']);
+    $this->contactIDs[] = $contactA = $this->individualCreate(['gender_id:name' => 'Female']);
     // Create address for contact A.
     $params = [
       'contact_id' => $contactA,
-      'location_type_id' => 'Home',
+      'location_type_id:name' => 'Home',
       'street_address' => 'Ambachtstraat 23',
       'postal_code' => '6971 BN',
       'country_id' => '1152',
       'city' => 'Brummen',
       'is_primary' => 1,
     ];
-    $result = $this->callAPISuccess('address', 'create', $params);
+    $result = $this->createTestEntity('Address', $params);
     $addressId = $result['id'];
 
-    $this->callAPISuccess('email', 'create', [
-      'id' => $this->callAPISuccessGetValue('Email', ['contact_id' => $params['contact_id'], 'return' => 'id']),
-      'location_type_id' => 'Home',
-      'email' => 'home@example.com',
-      'is_primary' => 1,
-    ]);
-    $this->callAPISuccess('email', 'create', ['contact_id' => $params['contact_id'], 'location_type_id' => 'Work', 'email' => 'work@example.com', 'is_primary' => 0]);
+    Email::update()
+      ->addWhere('contact_id', '=', $params['contact_id'])
+      ->setValues([
+        'location_type_id:name' => 'Home',
+        'email' => 'home@example.com',
+        'is_primary' => 1,
+      ]
+     )->execute();
+
+    $this->createTestEntity('Email', ['contact_id' => $params['contact_id'], 'location_type_id:name' => 'Work', 'email' => 'work@example.com', 'is_primary' => 0]);
 
     $params['is_primary'] = 0;
     $params['location_type_id'] = 'Work';
     $this->callAPISuccess('address', 'create', $params);
     $this->contactIDs[] = $contactB = $this->individualCreate([], 1);
 
-    $this->callAPISuccess('address', 'create', [
+    $this->createTestEntity('Address', [
       'contact_id' => $contactB,
-      'location_type_id' => 'Home',
+      'location_type_id:name' => 'Home',
       'master_id' => $addressId,
     ]);
     $this->masterAddressID = $addressId;

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -508,7 +508,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
    */
   public function createDomainContacts(): void {
     try {
-      $this->organizationCreate(['api.Email.create' => ['email' => 'fixme.domainemail@example.org']]);
+      $this->organizationCreate(['email' => 'fixme.domainemail@example.org']);
       $this->organizationCreate([
         'organization_name' => 'Second Domain',
         'api.Email.create' => ['email' => 'domainemail2@example.org'],

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -59,7 +59,13 @@ class api_v3_ACLPermissionTest extends CiviUnitTestCase {
     parent::setUp();
     CRM_Core_BAO_ConfigSetting::enableAllComponents();
     CRM_Core_DAO::createTestObject('CRM_Pledge_BAO_Pledge', [], 1, 0);
-    $this->callAPISuccess('Phone', 'create', ['id' => $this->individualCreate(['email' => '']), 'phone' => '911', 'location_type_id' => 'Home']);
+    $this->createTestEntity('Contact', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Anthony',
+      'last_name' => 'Doe',
+      'phone_primary.phone' => 911,
+      'phone_primary.location_type_id:label' => 'Home',
+    ], 'test');
     $this->prepareForACLs();
   }
 

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -2581,14 +2581,16 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testContactGetReturnValues(): void {
+    $contactID = $this->individualCreate([
+      'nick_name' => 'Bob',
+      'email_primary.email' => 'e@mail.com',
+      'phone_primary.phone' => '456',
+    ]);
     $extraParams = [
       'nick_name' => 'Bob',
-      'phone' => '456',
       'email' => 'e@mail.com',
+      'phone' => '456',
     ];
-    $contactID = $this->individualCreate($extraParams);
-    //actually it turns out the above doesn't create a phone
-    $this->callAPISuccess('phone', 'create', ['contact_id' => $contactID, 'phone' => '456']);
     $result = $this->callAPISuccess('contact', 'getsingle', ['id' => $contactID]);
     foreach ($extraParams as $key => $value) {
       $this->assertEquals($result[$key], $value);


### PR DESCRIPTION
Overview
----------------------------------------
Reduce reliance from ContactTest trait on apiv3 trait

Before
----------------------------------------
ContactTestTrait relies on apiv3TestTrait - both set public $apiversion = 4;

After
----------------------------------------
The dependence is very narrow - only one fall through uses apiv3 / the apiv3 trait

Technical Details
----------------------------------------
With a little more work we could switch to apiv4 only in this trait - since it is set up only that is what it should be

Comments
----------------------------------------

