### PR TITLE
Extract CRM_Member_BAO_Membership::getCalculatedDates(), switch OrderCompleteSubscriber to apiv4

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -647,6 +647,68 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
   }
 
   /**
+   * Calculate join/start/end dates for a membership from num_terms.
+   *
+   * This replicates the date-calculation civicrm_api3_membership_create()
+   * has always done itself before calling this BAO (see the 'Fixme: This
+   * code belongs in the BAO' comments there, which this is finally
+   * addressing) - centralised here so other callers building membership
+   * params directly don't have to duplicate the same logic.
+   *
+   * Note this is deliberately separate from the date-filling this class's
+   * own create() already does for brand-new memberships with no dates
+   * supplied at all (see the empty($params['id']) block in create()) - that
+   * covers a different case (no dates given) than this does (num_terms
+   * given, to extend/renew regardless of whether dates were given).
+   *
+   * 'num_terms' itself is really an apiv3 pseudo-param - it isn't a real
+   * civicrm_membership column, it only exists to trigger this calculation.
+   * Worth reconsidering whether it should exist as a param at all, versus
+   * this function (or its callers) just always being explicit about which
+   * calculation they want.
+   *
+   * Intended to be merged onto existing params via array union, so any
+   * date already explicitly set is left untouched:
+   *   $params += CRM_Member_BAO_Membership::getCalculatedDates($params);
+   *
+   * @param array $params
+   *   Must include 'membership_type_id'. May include 'id' (an existing
+   *   membership - triggers renewal-date calculation instead of
+   *   new-membership dates), 'num_terms', 'join_date', 'start_date',
+   *   'end_date'.
+   *
+   * @return array
+   *   Zero or more of 'join_date', 'start_date', 'end_date'.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function getCalculatedDates(array $params): array {
+    if (!empty($params['id']) && empty($params['num_terms'])) {
+      return [];
+    }
+    if (empty($params['id'])) {
+      // This is a new membership - calculate the membership dates.
+      $calculatedDates = CRM_Member_BAO_MembershipType::getDatesForMembershipType(
+        $params['membership_type_id'],
+        $params['join_date'] ?? NULL,
+        $params['start_date'] ?? NULL,
+        $params['end_date'] ?? NULL,
+        $params['num_terms'] ?? 1
+      );
+    }
+    else {
+      // This is an existing membership - calculate the dates after renewal.
+      $calculatedDates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType(
+        $params['id'],
+        NULL,
+        $params['membership_type_id'] ?? NULL,
+        $params['num_terms']
+      );
+    }
+    return array_intersect_key($calculatedDates, array_flip(['join_date', 'start_date', 'end_date']));
+  }
+
+  /**
    * Delete related memberships.
    *
    * @param int $ownerMembershipId

--- a/Civi/Membership/OrderCompleteSubscriber.php
+++ b/Civi/Membership/OrderCompleteSubscriber.php
@@ -142,7 +142,8 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
       //so make status override false.
       $membershipParams['is_override'] = FALSE;
       $membershipParams['status_override_end_date'] = 'null';
-      civicrm_api3('Membership', 'create', $membershipParams);
+      $membershipParams += \CRM_Member_BAO_Membership::getCalculatedDates($membershipParams);
+      Membership::update(FALSE)->setValues($membershipParams)->execute();
     }
   }
 

--- a/api/v3/Membership.php
+++ b/api/v3/Membership.php
@@ -86,38 +86,7 @@ function civicrm_api3_membership_create($params) {
   $values = [];
   _civicrm_api3_custom_format_params($params, $values, 'Membership');
   $params = array_merge($params, $values);
-
-  // Calculate membership dates
-  // Fixme: This code belongs in the BAO
-  if (empty($params['id']) || !empty($params['num_terms'])) {
-    // If this is a new membership or we have a specified number of terms calculate membership dates.
-    if (empty($params['id'])) {
-      // This is a new membership, calculate the membership dates.
-      $calcDates = CRM_Member_BAO_MembershipType::getDatesForMembershipType(
-        $params['membership_type_id'],
-        $params['join_date'] ?? NULL,
-        $params['start_date'] ?? NULL,
-        $params['end_date'] ?? NULL,
-        $params['num_terms'] ?? 1
-      );
-    }
-    else {
-      // This is an existing membership, calculate the membership dates after renewal
-      // num_terms is treated as a 'special sauce' for is_renewal but this
-      // isn't really helpful for completing pendings.
-      $calcDates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType(
-        $params['id'],
-        NULL,
-        $params['membership_type_id'] ?? NULL,
-        $params['num_terms']
-      );
-    }
-    foreach (['join_date', 'start_date', 'end_date'] as $date) {
-      if (empty($params[$date]) && isset($calcDates[$date])) {
-        $params[$date] = $calcDates[$date];
-      }
-    }
-  }
+  $params += CRM_Member_BAO_Membership::getCalculatedDates($params);
 
   // Fixme: This code belongs in the BAO
   $ids = [];


### PR DESCRIPTION

Overview
----------------------------------------
Extract CRM_Member_BAO_Membership::getCalculatedDates(), switch OrderCompleteSubscriber to apiv4

Before
----------------------------------------
OrderCompleteSubscriber uses apiv3 

After
----------------------------------------
OrderCompleteSubscriber uses apiv4 - calls an extra function to get the dates that apiv3 was filling in

Technical Details
----------------------------------------
This verbose spiel is claude's workings - but basically the only thing apiv3 was adding was the date calc - so we keep it

civicrm_api3_membership_create() has always calculated num_terms-triggered join/start/end dates itself before calling the BAO (flagged in-place with 'Fixme: This code belongs in the BAO'), so that logic had no home other callers could share. Extracted it to getCalculatedDates(), intended to be merged onto params via array union so anything already explicit wins: $params += CRM_Member_BAO_Membership::getCalculatedDates($params). api/v3/Membership.php now calls it instead of duplicating the calculation. Placed after the class's core CRUD methods (add/create/retrieve/delete).

Civi\Membership\OrderCompleteSubscriber now calls this new function too, and its Membership write switches from civicrm_api3() to Civi\Api4\Membership::update() (not create(). skipStatusCal/is_override/status_override_end_date/ membership_activity_status are read directly by the BAO regardless of api version, so they carry over unchanged. The apiv4 action's version=4 tag also makes the BAO skip legacy line-item reprocessing that this call site doesn't need, since CRM_Financial_BAO_Order already owns line items for orders created via the Order api.


Comments
----------------------------------------
Test cover is good on this