### PR TITLE
Switch createRelatedMemberships() deceased/expired branch to apiv4

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1357,11 +1357,6 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
         //don't calculate status again in create( );
         $params['skipStatusCal'] = TRUE;
 
-        //do create activity if we changed status.
-        if ($params['status_id'] != $relMembership->status_id) {
-          $params['createActivity'] = TRUE;
-        }
-
         //CRM-20707 - include start/end date
         $params['start_date'] = $membership->start_date;
         $params['end_date'] = $membership->end_date;
@@ -1376,10 +1371,13 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
         // CRM-20966: Do not create membership_payment record for inherited membership.
         unset($params['relate_contribution_id']);
 
+        // only used above, not by the create/save calls below.
+        unset($params['action']);
+
         if (($params['status_id'] == $deceasedStatusId) || ($params['status_id'] == $expiredStatusId)) {
           // related membership is not active so does not count towards maximum
           if (!self::hasExistingInheritedMembership($params)) {
-            civicrm_api3('Membership', 'create', $params);
+            \Civi\Api4\Membership::save(FALSE)->addRecord($params)->execute();
           }
         }
         else {


### PR DESCRIPTION
Also drops two dead params riding along into that call: 'createActivity' was set but never read anywhere in the codebase, and 'action' is only used earlier in this same function, not by the create/save call.


this has good test cover - including custom fields