### PR TITLE
Riverlea: fix FormBuilder Admin dropdown hover background regression

### DIFF
--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -442,6 +442,9 @@
   justify-content: center;
   background: var(--crm-dropdown-danger-bg-color);
 }
+#afGuiEditor .dropdown-menu a:has(.text-danger):is(:hover,:focus) {
+  background: color-mix(in srgb,var(--crm-dropdown-danger-bg-color) 75%,#000 25%);
+}
 #afGuiEditor .dropdown-menu .text-danger,
 #afGuiEditor .dropdown-menu .text-danger i.crm-i::before {
   color: var(--crm-danger-text-color);


### PR DESCRIPTION
Overview
----------------------------------------
6.18 introduced multiple dropdown background hover colour fixes (https://github.com/civicrm/civicrm-core/pull/36189) but it likely introduced a new regression for a unique dropdown background hover color pattern seen just in Form Builder Editor. This fixes that.

Before
----------------------------------------
Hover state on 'delete' button:

<img width="233" height="325" alt="image" src="https://github.com/user-attachments/assets/7c796375-c88b-46e9-8fd0-7e2e3a6a8a7e" /> <img width="235" height="372" alt="image" src="https://github.com/user-attachments/assets/2d3bf92c-7ee7-4dfd-9322-67d7da2396c8" /> <img width="229" height="327" alt="image" src="https://github.com/user-attachments/assets/38f02f50-a7f8-48d7-8fbf-efdadeb2a093" /> <img width="228" height="323" alt="image" src="https://github.com/user-attachments/assets/b325c91b-c92c-4405-aa50-e818f1c0218f" />

After
----------------------------------------
Hover state on 'delete' button:

<img width="234" height="337" alt="image" src="https://github.com/user-attachments/assets/7b2cfdea-9125-4d96-930e-a9ab53cb8bb0" /> <img width="231" height="370" alt="image" src="https://github.com/user-attachments/assets/bc564a07-7e08-4a89-b657-d7ccc90e9a6d" /> <img width="230" height="324" alt="image" src="https://github.com/user-attachments/assets/e0121ca0-3524-432c-ab39-76e80823626b" /> <img width="228" height="326" alt="image" src="https://github.com/user-attachments/assets/e24d4f93-53d7-4f86-8eb2-d1e05dda1873" />

Technical Details
----------------------------------------
This is tightly scoped to Form Builder Editor, dropdown links that contain 'text-danger'. For the record, the pattern here of putting a text-danger span inside a link isn't ideal - there's a dozen lines of css needed to accomadate that.

Color-mix is used to create a darker hover colour, which should ensure this remains with the majority of values for `--crm-dropdown-danger-bg-color` and `--crm-danger-text-color`. But if the text color was dark and the background was close to that (which isn't the case with any of these streams), then the 25% darker tint could reduce accessibility.