### PR TITLE
Switch v3 Profile.Submit api to use Order for membership

### DIFF
--- a/api/v3/Profile.php
+++ b/api/v3/Profile.php
@@ -16,9 +16,14 @@
  *
  * @package CiviCRM_APIv3
  */
+use Civi\Api4\LineItem;
+use Civi\Api4\Order;
+use Civi\Api4\Payment;
 
 /**
  * Retrieve Profile field values.
+ *
+ * @deprecated this approach has been superseded by form builder and apiv4.
  *
  * NOTE this api is not standard & since it is tested we need to honour that
  * but the correct behaviour is for it to return an id indexed array as this supports
@@ -27,15 +32,12 @@
  *
  * Note that if contact_id is empty an array of defaults is returned
  *
- * @param array $params
- *   Associative array of property name/value.
- *   pairs to get profile field values
- *
+ * @param  array $params
  * @return array
+ *
  * @throws \CRM_Core_Exception
- * @throws CRM_Core_Exception
  */
-function civicrm_api3_profile_get($params) {
+function civicrm_api3_profile_get(array $params): array {
   $nonStandardLegacyBehaviour = is_numeric($params['profile_id']);
   if (!empty($params['check_permissions']) && !empty($params['contact_id']) && !1 === civicrm_api3('contact', 'getcount', ['contact_id' => $params['contact_id'], 'check_permissions' => 1])) {
     throw new CRM_Core_Exception('permission denied');
@@ -135,14 +137,16 @@ function _civicrm_api3_profile_get_spec(&$params) {
 /**
  * Submit a set of fields against a profile.
  *
+ * @deprecated this approach has been superseded by form builder and apiv4.
+ *
  * Note choice of submit versus create is discussed CRM-13234 & related to the fact
  * 'profile' is being treated as a data-entry entity
  *
  * @param array $params
  *
- * @throws CRM_Core_Exception
  * @return array
  *   API result array
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_profile_submit($params) {
   $profileID = _civicrm_api3_profile_getProfileID($params['profile_id']);
@@ -230,14 +234,29 @@ function civicrm_api3_profile_submit($params) {
       $contactParams[_civicrm_api3_profile_translate_fieldnames_for_bao($fieldName)] = $value;
     }
   }
-  if (isset($contactParams['api.contribution.create'], $contactParams['api.membership.create'])) {
-    $contactParams['api.membership_payment.create'] = [
-      'contribution_id' => '$value.api.contribution.create.id',
-      'membership_id' => '$value.api.membership.create.id',
-    ];
-  }
+  // Membership creation (& its paying contribution, if any) is handled via
+  // apiv4 below rather than the v3 chained-api mechanism, so it can use the
+  // Order api to correctly link a contribution to the membership it pays for.
+  $membershipParams = $contactParams['api.membership.create'] ?? NULL;
+  unset($contactParams['api.membership.create']);
+  $membershipContributionParams = NULL;
+  $deferredParticipantParams = NULL;
 
-  if (isset($contactParams['api.contribution.create'], $contactParams['api.participant.create'])) {
+  if ($membershipParams !== NULL && isset($contactParams['api.contribution.create'])) {
+    $membershipContributionParams = $contactParams['api.contribution.create'];
+    unset($contactParams['api.contribution.create']);
+
+    if (isset($contactParams['api.participant.create'])) {
+      // The participant fee was going to share this same contribution via the
+      // v3 chain ('$value.api.contribution.create.id'). Since that contribution
+      // is now created via the v4 Order api (to link it to the membership),
+      // defer participant creation until we have the Order's real
+      // contribution id, rather than the v3 backreference.
+      $deferredParticipantParams = $contactParams['api.participant.create'];
+      unset($contactParams['api.participant.create'], $contactParams['api.participant_payment.create']);
+    }
+  }
+  elseif (isset($contactParams['api.contribution.create'], $contactParams['api.participant.create'])) {
     $contactParams['api.participant_payment.create'] = [
       'contribution_id' => '$value.api.contribution.create.id',
       'participant_id' => '$value.api.participant.create.id',
@@ -259,7 +278,78 @@ function civicrm_api3_profile_submit($params) {
     $profileParams['api.activity.create'] = $activityParams;
   }
 
-  return civicrm_api3('contact', 'create', $profileParams);
+  $contact = civicrm_api3('contact', 'create', $profileParams);
+
+  if ($membershipParams !== NULL) {
+    $contactID = $contact['id'];
+    $membershipParams['contact_id'] = $membershipParams['contact_id'] ?? $contactID;
+
+    if ($membershipContributionParams !== NULL) {
+      $membershipContributionParams['contact_id'] = $membershipContributionParams['contact_id'] ?? $contactID;
+
+      // Order::create() always creates the contribution as 'Pending' - that's
+      // a separate concept from what status the caller actually asked for
+      // (e.g. membership_batch_entry submits contribution_status_id => Completed
+      // for payments already received). Capture the requested status, then
+      // record a Payment below if it means the contribution should be paid off.
+      $requestedStatus = $membershipContributionParams['contribution_status_id:name']
+        ?? (!empty($membershipContributionParams['contribution_status_id'])
+          ? CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $membershipContributionParams['contribution_status_id'])
+          : NULL);
+      unset($membershipContributionParams['contribution_status_id'], $membershipContributionParams['contribution_status_id:name']);
+      // 'batch_id' isn't a real Contribution field (batches link via
+      // civicrm_entity_batch) - the v3 wrapper tolerated it as a no-op, but
+      // apiv4 Contribution::create() would reject an unrecognised field.
+      unset($membershipContributionParams['batch_id']);
+
+      $lineItem = ['membership_type_id' => $membershipParams['membership_type_id'] ?? NULL];
+      foreach ($membershipParams as $key => $value) {
+        if ($key === 'membership_type_id') {
+          continue;
+        }
+        $lineItem[$key === 'id' ? 'entity_id' : ('entity_id.' . $key)] = $value;
+      }
+      $lineItem['line_total'] = $lineItem['unit_price'] = $membershipContributionParams['total_amount'] ?? 0;
+
+      $order = Order::create(FALSE)
+        ->setContributionValues($membershipContributionParams)
+        ->addLineItem($lineItem)
+        ->execute()->single();
+      $contributionID = $order['id'];
+      $membershipID = LineItem::get(FALSE)
+        ->addWhere('contribution_id', '=', $contributionID)
+        ->addWhere('entity_table', '=', 'civicrm_membership')
+        ->addSelect('entity_id')
+        ->execute()->first()['entity_id'];
+
+      if ($requestedStatus === 'Completed') {
+        Payment::create(FALSE)
+          ->addValue('contribution_id', $contributionID)
+          ->addValue('total_amount', $lineItem['line_total'])
+          ->addValue('trxn_date', $membershipContributionParams['receive_date'] ?? 'now')
+          ->execute();
+      }
+
+      $contact['values'][$contact['id']]['api.contribution.create'] = ['is_error' => 0, 'id' => $contributionID, 'values' => [$contributionID => $order]];
+      $contact['values'][$contact['id']]['api.membership.create'] = ['is_error' => 0, 'id' => $membershipID];
+
+      if ($deferredParticipantParams !== NULL) {
+        $deferredParticipantParams['contact_id'] = $deferredParticipantParams['contact_id'] ?? $contactID;
+        $participant = civicrm_api3('participant', 'create', $deferredParticipantParams);
+        civicrm_api3('participant_payment', 'create', [
+          'contribution_id' => $contributionID,
+          'participant_id' => $participant['id'],
+        ]);
+        $contact['values'][$contact['id']]['api.participant.create'] = $participant;
+      }
+    }
+    else {
+      $membership = \Civi\Api4\Membership::save(FALSE)->addRecord($membershipParams)->execute()->single();
+      $contact['values'][$contact['id']]['api.membership.create'] = ['is_error' => 0, 'id' => $membership['id'], 'values' => [$membership['id'] => $membership]];
+    }
+  }
+
+  return $contact;
 }
 
 /**
@@ -341,7 +431,7 @@ function civicrm_api3_profile_apply($params) {
     CRM_Core_Permission::EDIT
   );
 
-  list($data, $contactDetails) = CRM_Contact_BAO_Contact::formatProfileContactParams($params,
+  [$data, $contactDetails] = CRM_Contact_BAO_Contact::formatProfileContactParams($params,
     $profileFields,
     $params['contact_id'] ?? NULL,
     $params['profile_id'],
@@ -489,7 +579,7 @@ function _civicrm_api3_buildprofile_submitfields($profileID, $optionsBehaviour, 
     if (!$field['is_active']) {
       continue;
     }
-    list($entity, $fieldName) = _civicrm_api3_map_profile_fields_to_entity($field);
+    [$entity, $fieldName] = _civicrm_api3_map_profile_fields_to_entity($field);
     $aliasArray = [];
     // Use alias to handle the inconsistency between -Primary and -primary suffixes
     if (strtolower($fieldName) != $fieldName) {

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -57,25 +57,6 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
   }
 
   /**
-   * Check Without ProfileId.
-   */
-  public function testProfileGetWithoutProfileId(): void {
-    $this->callAPIFailure('profile', 'get', ['contact_id' => 1],
-      'Mandatory key(s) missing from params array: profile_id'
-    );
-  }
-
-  /**
-   * Check with no invalid profile Id.
-   */
-  public function testProfileGetInvalidProfileId(): void {
-    $this->callAPIFailure('profile', 'get', [
-      'contact_id' => 1,
-      'profile_id' => 1000,
-    ]);
-  }
-
-  /**
    * Check with success.
    */
   public function testProfileGet(): void {
@@ -86,7 +67,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'profile_id' => $this->_profileID,
       'contact_id' => $contactId,
     ];
-    $result = $this->callAPISuccess('profile', 'get', $params)['values'];
+    $result = $this->callAPIV3Success('profile', 'get', $params)['values'];
     foreach ($expected as $profileField => $value) {
       $this->assertEquals($value, $result[$profileField]);
     }
@@ -109,7 +90,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'field_type' => 'Contact',
     ]);
     $this->callAPISuccess('Address', 'get', ['contact_id' => $this->_contactID, 'api.Address.create' => [$this->getCustomFieldName() => 'my field']]);
-    $this->callAPISuccess('Profile', 'get', ['profile_id' => $this->_profileID, 'contact_id' => $this->_contactID])['values'];
+    $this->callAPIV3Success('profile', 'get', ['profile_id' => $this->_profileID, 'contact_id' => $this->_contactID])['values'];
   }
 
   /**
@@ -124,7 +105,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    $result = $this->callAPISuccess('profile', 'get', $params)['values'];
+    $result = $this->callAPIV3Success('profile', 'get', $params)['values'];
     foreach ($expected as $profileField => $value) {
       $this->assertEquals($value, $result[$this->_profileID][$profileField], ' error message: ' . "missing/mismatching value for $profileField");
     }
@@ -162,7 +143,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    $result = $this->callAPISuccess('profile', 'get', $params)['values'];
+    $result = $this->callAPIV3Success('profile', 'get', $params)['values'];
     $this->assertEquals('abc1', $result[1]['first_name']);
     $this->assertEquals([
       'billing_first_name' => 'abc1',
@@ -202,7 +183,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ];
 
-    $result = $this->callAPISuccess('profile', 'get', $params);
+    $result = $this->callAPIV3Success('profile', 'get', $params);
     $this->assertEquals('abc1', $result['values'][1]['first_name']);
     $this->assertEquals([
       'billing_first_name' => 'abc1',
@@ -228,7 +209,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'profile_id' => ['Billing'],
     ];
 
-    $result = $this->callAPISuccess('profile', 'get', $params)['values'];
+    $result = $this->callAPIV3Success('profile', 'get', $params)['values'];
     $this->assertEquals([
       'billing_first_name' => '',
       'billing_middle_name' => '',
@@ -294,7 +275,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
   public function testContactActivityGetSuccess(): void {
     [$params, $expected] = $this->createContactWithActivity();
 
-    $result = $this->callAPISuccess('profile', 'get', $params);
+    $result = $this->callAPIV3Success('profile', 'get', $params);
 
     foreach ($expected as $profileField => $value) {
       $this->assertEquals($value, $result['values'][$profileField], ' error message: ' . "missing/mismatching value for $profileField"
@@ -387,7 +368,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $this->addCustomFieldToProfile($profile['id']);
     // Add some more fields
 
-    $result = $this->callAPISuccess('profile', 'getfields', [
+    $result = $this->callAPIV3Success('profile', 'getfields', [
       'action' => 'submit',
       'profile_id' => $profile['id'],
     ]);
@@ -407,7 +388,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
    * Check getfields works & gives us our fields - participant profile.
    */
   public function testGetFieldsParticipantProfile(): void {
-    $result = $this->callAPISuccess('profile', 'getfields', [
+    $result = $this->callAPIV3Success('profile', 'getfields', [
       'action' => 'submit',
       'profile_id' => 'participant_status',
       'get_options' => 'all',
@@ -422,7 +403,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
    * (getting to the end with no e-notices is pretty good evidence it's working).
    */
   public function testGetFieldsMembershipBatchProfile(): void {
-    $result = $this->callAPISuccess('profile', 'getfields', [
+    $result = $this->callAPIV3Success('profile', 'getfields', [
       'action' => 'submit',
       'profile_id' => 'membership_batch_entry',
       'get_options' => 'all',
@@ -446,7 +427,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('uf_group', 'get', ['return' => 'id'])['values'];
     $profileIDs = array_keys($result);
     foreach ($profileIDs as $profileID) {
-      $this->callAPISuccess('profile', 'getfields', [
+      $this->callAPIV3Success('profile', 'getfields', [
         'action' => 'submit',
         'profile_id' => $profileID,
         'get_options' => 'all',
@@ -535,21 +516,21 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'contact_id' => $contactId,
     ], $updateParams);
 
-    $this->callAPISuccess('profile', 'submit', $params);
+    $this->callAPIV3Success('profile', 'submit', $params);
 
     $getParams = [
       'profile_id' => $this->_profileID,
       'contact_id' => $contactId,
     ];
-    $profileDetails = $this->callAPISuccess('profile', 'get', $getParams);
+    $profileDetails = $this->callAPIV3Success('profile', 'get', $getParams);
 
     foreach ($updateParams as $profileField => $value) {
       $this->assertEquals($value, $profileDetails['values'][$profileField], "missing/mismatching value for $profileField");
     }
     unset($params['email-primary']);
     $params['email-Primary'] = 'my@mail.com';
-    $this->callAPISuccess('profile', 'submit', $params);
-    $profileDetails = $this->callAPISuccess('profile', 'get', $getParams);
+    $this->callAPIV3Success('profile', 'submit', $params);
+    $profileDetails = $this->callAPIV3Success('profile', 'get', $getParams);
     $this->assertEquals('my@mail.com', $profileDetails['values']['email-Primary']);
   }
 
@@ -563,7 +544,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $this->_membershipTypeID = $this->membershipTypeCreate();
 
     $membershipTypes = $this->callAPISuccess('membership_type', 'get', []);
-    $profileFields = $this->callAPISuccess('profile', 'getfields', [
+    $profileFields = $this->callAPIV3Success('profile', 'getfields', [
       'get_options' => 'all',
       'action' => 'submit',
       'profile_id' => 'membership_batch_entry',
@@ -582,7 +563,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
    * around that goes on.
    */
   public function testMembershipGetFieldsOrder(): void {
-    $result = $this->callAPISuccess('profile', 'getfields', [
+    $result = $this->callAPIV3Success('profile', 'getfields', [
       'action' => 'submit',
       'profile_id' => 'membership_batch_entry',
     ])['values'];
@@ -598,12 +579,14 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
 
   /**
    * Check we can submit membership batch profiles (create mode).
+   *
+   * This profile has both Membership & Contribution fields, so submit
+   * should route through the apiv4 Order api to link them, rather than
+   * creating two independent records.
    */
   public function testProfileSubmitMembershipBatch(): void {
-    // @todo - figure out why this doesn't pass validate financials
-    $this->isValidateFinancialsOnPostAssert = FALSE;
     $this->_contactID = $this->individualCreate();
-    $this->callAPISuccess('profile', 'submit', [
+    $this->callAPIV3Success('profile', 'submit', [
       'profile_id' => 'membership_batch_entry',
       'financial_type_id' => 1,
       'membership_type' => $this->_membershipTypeID,
@@ -613,60 +596,59 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'receive_date' => 'now',
       'contact_id' => $this->_contactID,
     ]);
+
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->_contactID]);
+    $this->assertEquals($this->_membershipTypeID, $membership['membership_type_id']);
+
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $this->_contactID]);
+    $this->assertEquals(10, $contribution['total_amount']);
+    $this->assertEquals(1, $contribution['financial_type_id']);
+    // contribution_status_id => 1 (Completed) was requested; since Order::create()
+    // always creates a Pending contribution, submit() should have recorded a
+    // Payment to bring it to Completed.
+    $this->assertEquals('Completed', $contribution['contribution_status']);
+
+    // The contribution & membership should be linked via a line item, not
+    // just two independent records.
+    $this->callAPISuccessGetSingle('line_item', [
+      'contribution_id' => $contribution['id'],
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $membership['id'],
+    ]);
   }
 
   /**
-   * Check contact activity profile without activity id.
-   */
-  public function testContactActivitySubmitWithoutActivityId(): void {
-    [$params, $expected] = $this->createContactWithActivity();
-
-    $params = array_merge($params, $expected);
-    unset($params['activity_id']);
-    $this->callAPIFailure('profile', 'submit', $params, 'Mandatory key(s) missing from params array: activity_id');
-  }
-
-  /**
-   * Check contact activity profile wrong activity id.
-   */
-  public function testContactActivitySubmitWrongActivityId(): void {
-    [$params, $expected] = $this->createContactWithActivity();
-    $params = array_merge($params, $expected);
-    $params['activity_id'] = 100001;
-    $this->callAPIFailure('profile', 'submit', $params, 'Invalid Activity Id (aid).');
-  }
-
-  /**
-   * Check contact activity profile with wrong activity type.
+   * Check we can submit a membership-only profile (no contribution field).
    *
-   * @throws \Exception
+   * This should create the membership directly via the apiv4 Membership api.
    */
-  public function testContactActivitySubmitWrongActivityType(): void {
+  public function testProfileSubmitMembershipOnly(): void {
+    $contactID = $this->individualCreate();
+    $profile = $this->callAPISuccess('uf_group', 'create', [
+      'group_type' => 'Membership',
+      'name' => 'test_membership_only_profile',
+      'title' => 'Membership Only',
+      'api.uf_field.create' => [
+        [
+          'field_name' => 'membership_type',
+          'is_required' => 1,
+          'visibility' => 'Public Pages and Listings',
+          'field_type' => 'Membership',
+          'label' => 'Membership Type',
+        ],
+      ],
+    ]);
+    $this->_profileID = $profile['id'];
 
-    $sourceContactId = $this->householdCreate();
+    $this->callAPIV3Success('profile', 'submit', [
+      'profile_id' => $this->_profileID,
+      'contact_id' => $contactID,
+      'membership_type' => $this->_membershipTypeID,
+    ]);
 
-    $activityParams = [
-      'source_contact_id' => $sourceContactId,
-      'activity_type_id' => '2',
-      'subject' => 'Test activity',
-      'activity_date_time' => '20110316',
-      'duration' => '120',
-      'location' => 'Pennsylvania',
-      'details' => 'a test activity',
-      'status_id' => '1',
-      'priority_id' => '1',
-    ];
-
-    $activity = $this->callAPISuccess('activity', 'create', $activityParams);
-
-    $activityValues = array_pop($activity['values']);
-
-    [$params, $expected] = $this->createContactWithActivity();
-
-    $params = array_merge($params, $expected);
-    $params['activity_id'] = $activityValues['id'];
-    $this->callAPIFailure('profile', 'submit', $params,
-      'This activity cannot be edited or viewed via this profile.');
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $contactID]);
+    $this->assertEquals($this->_membershipTypeID, $membership['membership_type_id']);
+    $this->callAPISuccessGetCount('Contribution', ['contact_id' => $contactID], 0);
   }
 
   /**
@@ -686,35 +668,13 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'activity_status_id' => '2',
     ];
     $profileParams = array_merge($params, $updateParams);
-    $this->callAPISuccess('profile', 'submit', $profileParams);
-    $result = $this->callAPISuccess('profile', 'get', $params)['values'];
+    $this->callAPIV3Success('profile', 'submit', $profileParams);
+    $result = $this->callAPIV3Success('profile', 'get', $params)['values'];
 
     foreach ($updateParams as $profileField => $value) {
       $this->assertEquals($value, $result[$profileField], ' error message: ' . "missing/mismatching value for $profileField"
       );
     }
-  }
-
-  /**
-   * Check profile apply Without ProfileId.
-   */
-  public function testProfileApplyWithoutProfileId(): void {
-    $params = [
-      'contact_id' => 1,
-    ];
-    $this->callAPIFailure('profile', 'apply', $params,
-      'Mandatory key(s) missing from params array: profile_id');
-  }
-
-  /**
-   * Check profile apply with no invalid profile Id.
-   */
-  public function testProfileApplyInvalidProfileId(): void {
-    $params = [
-      'contact_id' => 1,
-      'profile_id' => 1000,
-    ];
-    $this->callAPIFailure('profile', 'apply', $params);
   }
 
   /**
@@ -735,7 +695,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
       'state_province-1' => '1000',
     ];
 
-    $result = $this->callAPISuccess('profile', 'apply', $params);
+    $result = $this->callAPIV3Success('profile', 'apply', $params);
 
     // Expected field values
     $expected['contact'] = [
@@ -799,19 +759,19 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $tag_2 = $this->callAPISuccess('tag', 'create', ['name' => 'def'])['id'];
 
     $params['tag'] = "$tag_1,$tag_2";
-    $this->callAPISuccess('profile', 'submit', $params);
+    $this->callAPIV3Success('profile', 'submit', $params);
 
     $tags = $this->callAPISuccess('entityTag', 'get', ['entity_id' => $contactId]);
     $this->assertEquals(2, $tags['count']);
 
     $params['tag'] = [$tag_1];
-    $this->callAPISuccess('profile', 'submit', $params);
+    $this->callAPIV3Success('profile', 'submit', $params);
 
     $tags = $this->callAPISuccess('entityTag', 'get', ['entity_id' => $contactId]);
     $this->assertEquals(1, $tags['count']);
 
     $params['tag'] = '';
-    $this->callAPISuccess('profile', 'submit', $params);
+    $this->callAPIV3Success('profile', 'submit', $params);
 
     $tags = $this->callAPISuccess('entityTag', 'get', ['entity_id' => $contactId]);
     $this->assertEquals(0, $tags['count']);
@@ -839,7 +799,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     ]);
 
     $params['note'] = 'Hello 123';
-    $this->callAPISuccess('profile', 'submit', $params);
+    $this->callAPIV3Success('profile', 'submit', $params);
 
     $note = $this->callAPISuccessGetSingle('note', ['entity_id' => $contactId]);
     $this->assertEquals('Hello 123', $note['note']);
@@ -872,7 +832,7 @@ class api_v3_ProfileTest extends CiviUnitTestCase {
     $this->callAPIFailure('profile', 'submit', $params);
 
     $params['email_greeting_custom'] = 'Hello fool!';
-    $this->callAPISuccess('profile', 'submit', $params);
+    $this->callAPIV3Success('profile', 'submit', $params);
 
     // Api3 will not return custom greeting field so resorting to this
     $greeting = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'email_greeting_custom');


### PR DESCRIPTION
Overview
----------------------------------------
Switch v3 Profile.Submit api to use Order for membership

Before
----------------------------------------
Profile api is barely used but exists & uses v3 Membership api, also creating invalid financials & calling MembershipPayment directly

After
----------------------------------------
- it calls Order.create for membership & creates valid financial records
- it is marked as deprecated to make it clear it should not be used
- Some of the dumber failure tests are removed, in line with similar other apiv3 removals - people went wild on this cos they felt like they were writing tests without much effort but they also don't do much

Technical Details
----------------------------------------

Comments
----------------------------------------
