### PR TITLE
Stop setting unused typo

### DIFF
--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -551,10 +551,6 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       !$self->validatePaymentValues($self, $fields)
     ) {
       $errors['_qf_default'] = ts("Your payment information looks incomplete. Please go back to the main registration page, to complete payment information.");
-      $self->set('forcePayement', TRUE);
-    }
-    elseif ($button == 'skip') {
-      $self->set('forcePayement', TRUE);
     }
 
     return $errors;


### PR DESCRIPTION
Overview
----------------------------------------
Stop setting unused typo

Before
----------------------------------------
`     $self->set('forcePayement', TRUE);` but not otherwise found

After
----------------------------------------
poof

Technical Details
----------------------------------------
typos are good for grepping

Comments
----------------------------------------
