### PR TITLE
dev/core#6735 On a non-English website, the check number is invisible…

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -101,6 +101,13 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
 
     $paymentFields = $this->getPaymentFields();
     $this->assign('paymentFields', $paymentFields);
+
+    $this->assign('paymentInstrumentNames', CRM_Core_PseudoConstant::get(
+          'CRM_Financial_DAO_FinancialTrxn',
+          'payment_instrument_id',
+          ['labelColumn' => 'name', 'localize' => FALSE, 'onlyActive' => FALSE]
+    ));
+
     foreach ($paymentFields as $name => $paymentField) {
       if (!empty($paymentField['add_field'])) {
         $attributes = [

--- a/templates/CRM/Financial/Form/PaymentEdit.tpl
+++ b/templates/CRM/Financial/Form/PaymentEdit.tpl
@@ -30,23 +30,17 @@
 {literal}
 <script type="text/javascript">
 CRM.$(function ($) {
+  // Machine names keyed by option value. We must not compare the option label:
+  // it is translated and can be customised per-site.
+  var paymentInstrumentNames = {/literal}{$paymentInstrumentNames|@json_encode}{literal};
 
   showHideFieldsByPaymentInstrumentID();
   $('#payment_instrument_id').on('change', showHideFieldsByPaymentInstrumentID);
 
   function showHideFieldsByPaymentInstrumentID() {
-    var paymentInstrumentLabel = $('#payment_instrument_id option:selected').text();
-    if (paymentInstrumentLabel == ts('Credit Card')) {
-      $('.check_number-section').hide();
-      $('.card_type_id-section, .pan_truncation-section').show();
-    }
-    else if (paymentInstrumentLabel == ts('Check')) {
-      $('.card_type_id-section, .pan_truncation-section').hide();
-      $('.check_number-section').show();
-    }
-    else {
-      $('.card_type_id-section, .pan_truncation-section, .check_number-section').hide();
-    }
+    var paymentInstrumentName = paymentInstrumentNames[$('#payment_instrument_id').val()];
+    $('.check_number-section').toggle(paymentInstrumentName === 'Check');
+    $('.card_type_id-section, .pan_truncation-section').toggle(paymentInstrumentName === 'Credit Card');
   }
 });
 </script>


### PR DESCRIPTION
… on the payment modification screen

Overview
----------------------------------------
in the edit payement screen the field of check or Credit card is not visible if the website is non-english. I fix this problem with this PR. Now i can see the check field


Before
----------------------------------------
<img width="1094" height="381" alt="Desktop-screenshot-09-08-2026_03_40_PM" src="https://github.com/user-attachments/assets/1adf2f73-04ed-4ca4-8f80-e8159340171d" />


After
----------------------------------------
<img width="701" height="349" alt="{DC23B486-5AA4-4042-AED4-207D70BB9A99}" src="https://github.com/user-attachments/assets/0013e4b8-b713-4dd0-8031-bc1f15db613b" />

