### PR TITLE
PR Commands - Add/remove 'needs-rebase' label on /rebase

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN }}
         run: |
-          PR_JSON=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName,headRepository,headRepositoryOwner,baseRefName,state,mergeCommit)
+          PR_JSON=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName,headRepository,headRepositoryOwner,baseRefName,state,mergeCommit,labels)
 
           STATE=$(echo "$PR_JSON" | jq -r '.state')
           MERGE_COMMIT=$(echo "$PR_JSON" | jq -r '.mergeCommit.oid // empty')
@@ -60,6 +60,7 @@ jobs:
           HEAD_OWNER=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login // empty')
           HEAD_REPO=$(echo "$PR_JSON" | jq -r '.headRepository.name // empty')
           BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName')
+          HAS_NEEDS_REBASE=$(echo "$PR_JSON" | jq -r '[.labels[]?.name] | contains(["needs-rebase"])')
 
           echo "state=$STATE" >> $GITHUB_OUTPUT
           echo "merge_commit=$MERGE_COMMIT" >> $GITHUB_OUTPUT
@@ -67,6 +68,7 @@ jobs:
           echo "head_owner=$HEAD_OWNER" >> $GITHUB_OUTPUT
           echo "head_repo=$HEAD_REPO" >> $GITHUB_OUTPUT
           echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
+          echo "has_needs_rebase=$HAS_NEEDS_REBASE" >> $GITHUB_OUTPUT
 
       - name: Checkout upstream
         uses: actions/checkout@v6
@@ -144,6 +146,7 @@ jobs:
             fi
 
             echo "TARGET_BASE=$NEW_BASE" >> $GITHUB_ENV
+            echo "COMMAND_ACTION=$ACTION" >> $GITHUB_ENV
             echo "Running $ACTION to $NEW_BASE..."
 
             git fetch origin $base_branch
@@ -204,6 +207,11 @@ jobs:
 
                 gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "$COMMENT_BODY"
               fi
+            fi
+
+            if [ "$ACTION" = "rebase" ] && [ "${{ steps.pr_info.outputs.has_needs_rebase }}" = "true" ]; then
+              echo "Removing needs-rebase label..."
+              gh pr edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --remove-label "needs-rebase" || true
             fi
 
           elif [[ "$CMD" =~ ^/(lintroll|lint) ]]; then
@@ -289,3 +297,9 @@ jobs:
 
           # 3. Post comment
           gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "$MSG"
+
+          # 4. Add needs-rebase label if rebase failed
+          if [ "$COMMAND_ACTION" = "rebase" ]; then
+            echo "Adding needs-rebase label..."
+            gh pr edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --add-label "needs-rebase" || true
+          fi


### PR DESCRIPTION
## Overview
Adds the `needs-rebase` label when the `/rebase` PR command fails, and removes it if present when the command succeeds.