### PR TITLE
Convert BAO_membership:create to using apiv4

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1448,7 +1448,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
           // related membership already exists, so this is just an update
           if (isset($params['id'])) {
             if ($numRelatedAvailable > 0) {
-              CRM_Member_BAO_Membership::create($params);
+              Membership::save(FALSE)->addRecord($params)->execute();
               $numRelatedAvailable--;
             }
             else {
@@ -1468,7 +1468,7 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
           break;
         }
         if (!self::hasExistingInheritedMembership($params)) {
-          CRM_Member_BAO_Membership::create($params);
+          Membership::save(FALSE)->addRecord($params)->execute();
         }
         $numRelatedAvailable--;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Convert BAO_membership:create to using apiv4

Before
----------------------------------------
Uses BAO create method

After
----------------------------------------
Uses api

Technical Details
----------------------------------------
@mattwire - this should get rid of the last 2

Comments
----------------------------------------
Note I got Claude to do a double check:

● Good, there's existing test coverage in MembershipTest.php for related/inherited memberships, which should exercise this exact code path.                                
                                                                                                                                                                           
  Review: 5ae4e55195 — Convert BAO_membership:create to using apiv4                                                                                                        
                                                                                                                                                                           
  Verdict: looks correct. This is a small, well-scoped change converting two of the three CRM_Member_BAO_Membership::create($params) calls in createRelatedMemberships()   
  (the inherited/related-membership update and queued-insert branches) to Membership::save(FALSE)->addRecord($params)->execute().                                          
                                                                                                                                                                           
  I traced the concern that bit the earlier updateDeceasedMembersStatuses() conversion — that switching to apiv4 might silently drop legacy BAO-only flags like            
  skipStatusCal — and it doesn't apply here:                                                                                                                               
                                                                                                                                                                           
  - Membership::save()'s addRecord() does a raw array_merge with no field filtering (AbstractSaveAction::addRecord), and DAOActionTrait::write() calls                     
  $baoName::create($item) with the entire $item array intact when CRM_Member_BAO_Membership::create() exists and isn't @deprecated (confirmed — it isn't). So              
  skipStatusCal, start_date, end_date, status_id, owner_membership_id, and id (when present) all reach the legacy BAO exactly as before.                                   
  - The only new side effect is MembershipSaveTrait::write() injecting 'version' => 4', which makes create() skip its big v3-only post-processing block (line-item         
  creation, recordMembershipContribution, membership-payment linkage). That block was already neutralized for this call site by the explicit unset($params['lineItems'],   
  $params['line_item'], $params['contribution_status_id'], $params['relate_contribution_id']) a few lines above (per the CRM-16857/CRM-20966 comments), so skipping it is a
  no-op here, not a behavior change — if anything it's a small efficiency win.      
