### PR TITLE
SearchKit - Switch to custom columns when enabling tally

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -115,7 +115,7 @@
         const hasTally = !!this.display.settings.tally;
         if (!hasTally) {
           this.display.settings.tally = {label: ts('Totals'), header: false, footer: false};
-          this.setTallyDefaults();
+          this.setColumnMode('custom', true);
         }
         this.display.settings.tally[position] = !this.display.settings.tally[position];
         if (!this.display.settings.tally.header && !this.display.settings.tally.footer) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6682](https://lab.civicrm.org/dev/core/-/issues/6682).
Follows up on https://github.com/civicrm/civicrm-core/pull/35455.

When enabling tally/totals on a SearchKit table display, automatically switch the column mode to "Custom" (`setColumnMode('custom')`).

Before
----------------------------------------
When enabling totals on a table display that uses default columns from search (`columnMode === 'auto'`), the column mode remained set to "auto". Because default columns do not have tally settings, totals appeared broken and required manually toggling the column mode radio button to "Use custom columns".

After
----------------------------------------
Enabling totals on a table display automatically switches the column mode to "Custom" (`setColumnMode('custom')`), initializing the custom columns and configuring the default tally aggregate functions immediately.

