### PR TITLE
Add Sinjinsmiley to contributor-key.yml

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1658,6 +1658,10 @@
 
 - name        : Shira Miller
 
+- github      : Sinjinsmiley
+  name        : Simon East
+  organization: North Essex Heritage
+  
 - github      : spalmstr
   name        : Stephen Palmstrom
 


### PR DESCRIPTION
Add release-note attribution for my GitHub account following https://github.com/civicrm/civicrm-core/pull/36613 and https://github.com/civicrm/civicrm-core/pull/36672
