### PR TITLE
BAO_Membership - remove functionality from deprecated parameters

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -329,9 +329,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
       // Record contribution for this membership and create a MembershipPayment
       // @todo deprecate this.
       if (!empty($params['contribution_status_id'])) {
-        CRM_Core_Error::deprecatedWarning('creating a contribution via membership BAO is deprecated');
-        $memInfo = array_merge($params, ['membership_id' => $membership->id]);
-        $params['contribution'] = self::recordMembershipContribution($memInfo);
+        CRM_Core_Error::deprecatedWarning('creating a contribution via membership BAO is no longer possible');
       }
 
       // If the membership has no associated contribution then we ensure
@@ -351,28 +349,22 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
         // This could happen if there is no contribution or we are in one of many
         // weird and wonderful flows. This is scary code. Keep adding tests.
         if (!empty($params['line_item']) && empty($params['contribution_id'])) {
-
           foreach ($params['line_item'] as $priceSetId => $lineItems) {
             foreach ($lineItems as $lineIndex => $lineItem) {
               $lineMembershipType = $lineItem['membership_type_id'] ?? NULL;
               if (!empty($params['contribution'])) {
-                CRM_Core_Error::deprecatedWarning('passing contribution into Membership Create is deprecated - use the Order api to get the line items right.');
-                $params['line_item'][$priceSetId][$lineIndex]['contribution_id'] = $params['contribution']->id;
+                CRM_Core_Error::deprecatedWarning('passing contribution into Membership Create is non-functional and deprecated - use the Order api to get the line items right.');
               }
               if ($lineMembershipType && $lineMembershipType == ($params['membership_type_id'] ?? NULL)) {
                 $params['line_item'][$priceSetId][$lineIndex]['entity_id'] = $membership->id;
                 $params['line_item'][$priceSetId][$lineIndex]['entity_table'] = 'civicrm_membership';
-              }
-              elseif (!$lineMembershipType && !empty($params['contribution'])) {
-                $params['line_item'][$priceSetId][$lineIndex]['entity_id'] = $params['contribution']->id;
-                $params['line_item'][$priceSetId][$lineIndex]['entity_table'] = 'civicrm_contribution';
               }
             }
           }
           CRM_Price_BAO_LineItem::processPriceSet(
             $membership->id,
             $params['line_item'],
-            $params['contribution'] ?? NULL
+            NULL
           );
         }
       }


### PR DESCRIPTION


Overview
----------------------------------------
BAO_Membership - remove functionality from deprecated parameters

Passing contribution_status_id into BAO_Membership::create has always been obscure and undocumented. At the start of this year we added noisy deprecation for it - this keeps that noisy deprecation but removes the deprecated functionality

Before
----------------------------------------
Passing `contribution_status_id` into BAO_Membership::Create creates a contribution and emits deprecation noise
Passing `contribution` in as a BAO creates financial entities and emits noise - note we don't really think this was ever done - it is set when contribution_status_id is passed in

After
----------------------------------------
Passing `contribution_status_id` into BAO_Membership::Create emits deprecation noise
Passing `contribution` in as a BAO emits noise 

Technical Details
----------------------------------------
@mattwire 8 months is perhaps on the short side for a deprecation but these were always unpredictable obscure parameters and we know they do a poor job (at best) of creating financial entities

Comments
----------------------------------------
