### PR TITLE
PR Commands - Set git committer to civicrm-builder when PAT is present

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -81,8 +81,13 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           # Configure Git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "${{ secrets.PR_COMMANDS_PAT }}" ]; then
+            git config user.name "civicrm-builder"
+            git config user.email "civicrm-builder@users.noreply.github.com"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+          fi
 
           STATE="${{ steps.pr_info.outputs.state }}"
           MERGE_COMMIT="${{ steps.pr_info.outputs.merge_commit }}"


### PR DESCRIPTION
Overview
----------------------------------------
Configure Git committer to `civicrm-builder` in `pr-commands.yml` when `PR_COMMANDS_PAT` is set, falling back to `github-actions[bot]`.

Before
----------------------------------------
PR commands like `/port`, `/rebase`, `/squash`, and `/lintroll` resulted in commits having `github-actions[bot]` stamped as the Git committer, even when `PR_COMMANDS_PAT` was present and PR actions/pushes were authenticated as `civicrm-builder`.

After
----------------------------------------
When `secrets.PR_COMMANDS_PAT` is configured, the local Git committer identity is set to `civicrm-builder` (`civicrm-builder@users.noreply.github.com`). If the secret is not set, it falls back to `github-actions[bot]`.

Technical Details
----------------------------------------
Conditionally configures `user.name` and `user.email` based on `if [ -n "${{ secrets.PR_COMMANDS_PAT }}" ]` during the `Parse and Execute Command` step in `.github/workflows/pr-commands.yml`.

Comments
----------------------------------------
