### PR TITLE
Remove dead assignBillingName() call from processBillingAddress() from back office forms

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -573,8 +573,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
         CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'contact_type')
       );
     }
-
-    $this->assignBillingName($this->_params);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
Remove dead assignBillingName() call from processBillingAddress() from back office forms

Before
----------------------------------------
unnecessary assign

After
----------------------------------------
gone

Technical Details
----------------------------------------
I got claude to double check my own conclusions:

Checks done before removing:
- assignBillingName() has only one other caller (ContributionBase.php:856), a separate call in a different class hierarchy (the public contribution page wizard) that persists the name via $this->set() for later pages - unaffected by this change.
- processBillingAddress() itself is called from three places, all backoffice edit forms: CRM_Contribute_Form_Contribution.php:1229, CRM_Member_Form_MembershipRenewal.php:493, CRM_Member_Form_Membership.php:989.
- Searched every core .tpl for the 'billingName' variable this call assigns. It's only read in Event/Cart/Form/Checkout/Payment.tpl, Event/Form/Registration/Confirm.tpl, Event/Form/Registration/ThankYou.tpl, Contribute/Form/Contribution/Confirm.tpl, Contribute/Form/Contribution/ThankYou.tpl, and Contribute/Page/SubscriptionStatus.tpl - all public-facing wizard pages, none reachable from the three backoffice forms above.

So the assignment had no template consumer on any current call path.



Comments
----------------------------------------
