### PR TITLE
Remove irrelevant previously shared code fr0om back office contribution form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1760,13 +1760,9 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       'invoice_id' => $params['invoiceID'],
       'currency' => $params['currencyID'],
       'is_pay_later' => $params['is_pay_later'] ?? 0,
-      //configure cancel reason, cancel date and thankyou date
-      //from 'contribution' type profile if included
-      'cancel_reason' => $params['cancel_reason'] ?? 0,
-      'cancel_date' => isset($params['cancel_date']) ? CRM_Utils_Date::format($params['cancel_date']) : NULL,
-      'thankyou_date' => isset($params['thankyou_date']) ? CRM_Utils_Date::format($params['thankyou_date']) : NULL,
-      //setting to make available to hook - although seems wrong to set on form for BAO hook availability
-      'skipLineItem' => $params['skipLineItem'] ?? 0,
+      'cancel_reason' => $this->getSubmittedValue('cancel_reason'),
+      'cancel_date' => $this->getSubmittedValue('cancel_date'),
+      'thankyou_date' => $this->getSubmittedValue('thankyou_date'),
     ];
 
     if (!empty($params["is_email_receipt"])) {
@@ -1780,15 +1776,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     $contributionParams['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
-    if (isset($contributionParams['invoice_id'])) {
-      $contributionParams['id'] = CRM_Core_DAO::getFieldValue(
-        'CRM_Contribute_DAO_Contribution',
-        $contributionParams['invoice_id'],
-        'id',
-        'invoice_id'
-      );
-    }
-
     return $contributionParams;
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
Remove irrelevant previously shared code fr0om back office contribution form

Before
----------------------------------------
Code was shared with front end form and had some concepts not relevant to the back office form
- loading id from invoice_id - this would be a feature of using the form in edit mode, not some woo-woo
- setting cancel_date, thankyou_date from the profile - these are submitted values and we don't need to re-format. This is mostly removing the comment
- tinkering with `skipLineItems` - not  sure we can really support this intervention at a form level anywhere - but as we move to using Order::create definitely not. There isn't an obvious way you would set it via hook to get to this point and it looks like a 'good intention' from many iterations ago


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
