### PR TITLE
dev/core#6745 Use payment form to add payments to pending event

### DIFF
--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -178,25 +178,7 @@ class CRM_Event_Form_EventFees {
       $form->assign('currency', $defaults['participant_fee_currency']);
     }
 
-    // CRM-4395
-    if ($contriId = $form->get('onlinePendingContributionId')) {
-      $defaults['record_contribution'] = 1;
-      $contribution = new CRM_Contribute_DAO_Contribution();
-      $contribution->id = $contriId;
-      $contribution->find(TRUE);
-      foreach ([
-        'financial_type_id',
-        'payment_instrument_id',
-        'contribution_status_id',
-        'receive_date',
-        'total_amount',
-      ] as $f) {
-        $defaults[$f] = $contribution->$f;
-      }
-    }
-    else {
-      $defaults['contribution_status_id'] = CRM_Core_OptionGroup::getDefaultValue('contribution_status') ?? CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
-    }
+    $defaults['contribution_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
     return $defaults;
   }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -181,12 +181,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   public $_paymentId;
 
   /**
-   * @var null
-   * @todo add explanatory note about this
-   */
-  public $_onlinePendingContributionId;
-
-  /**
    * Params for creating a payment to add to the contribution.
    *
    * @var array
@@ -345,15 +339,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $this->buildEventFeeForm();
       CRM_Event_Form_EventFees::setDefaultValues($this);
     }
-
-    // CRM-4395, get the online pending contribution id.
-    $this->_onlinePendingContributionId = NULL;
-    if (!$this->_mode && $this->_id && ($this->_action & CRM_Core_Action::UPDATE)) {
-      $this->_onlinePendingContributionId = CRM_Contribute_BAO_Contribution::checkOnlinePendingContribution($this->_id,
-        'Event'
-      );
-    }
-    $this->set('onlinePendingContributionId', $this->_onlinePendingContributionId);
   }
 
   /**
@@ -623,27 +608,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
 
     $this->addSelect('role_id', ['multiple' => TRUE, 'class' => 'huge'], TRUE);
 
-    // CRM-4395
-    $checkCancelledJs = ['onchange' => 'return sendNotification( );'];
-    $confirmJS = NULL;
-    if ($this->_onlinePendingContributionId) {
-      $cancelledparticipantStatusId = array_search('Cancelled', CRM_Event_PseudoConstant::participantStatus());
-      $cancelledContributionStatusId = array_search('Cancelled',
-        CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name')
-      );
-      $checkCancelledJs = [
-        'onchange' => "checkCancelled( this.value, {$cancelledparticipantStatusId},{$cancelledContributionStatusId});",
-      ];
-
-      $participantStatusId = array_search('Pending from pay later',
-        CRM_Event_PseudoConstant::participantStatus()
-      );
-      $contributionStatusId = array_search('Completed',
-        CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name')
-      );
-      $confirmJS = ['onclick' => "return confirmStatus( {$participantStatusId}, {$contributionStatusId} );"];
-    }
-
     // get the participant status names to build special status array which is used to show notification
     // checkbox below participant status select
     $participantStatusName = CRM_Event_PseudoConstant::participantStatus();
@@ -668,7 +632,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
     }
 
-    $this->addSelect('status_id', $checkCancelledJs + [
+    $this->addSelect('status_id', [
+      'onchange' => 'return sendNotification( );',
       'options' => $statusOptions,
       'option_url' => 'civicrm/admin/participant_status',
     ], TRUE);
@@ -683,7 +648,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       'type' => 'upload',
       'name' => ts('Save'),
       'isDefault' => TRUE,
-      'js' => $confirmJS,
     ];
 
     $path = CRM_Utils_System::currentPath();
@@ -696,7 +660,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         'type' => 'upload',
         'name' => ts('Save and New'),
         'subName' => 'new',
-        'js' => $confirmJS,
       ];
     }
 
@@ -774,16 +737,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     // For single additions - show validation error if the contact has already been registered
     // for this event.
     if (($self->_action & CRM_Core_Action::ADD)) {
-      if ($self->_context === 'standalone') {
-        $contactId = $values['contact_id'] ?? NULL;
-      }
-      else {
-        $contactId = $self->_contactId;
-      }
-
       $eventId = $values['event_id'] ?? NULL;
 
-      $errorMsg += CRM_Event_BAO_Participant::validateExistingRegistration($contactId, $eventId, 'admin');
+      $errorMsg += CRM_Event_BAO_Participant::validateExistingRegistration($self->getContactID(), $eventId, 'admin');
 
       // TODO: No check for available spaces?
     }
@@ -986,6 +942,11 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
 
       $contributions = [];
+      // record_contribution is only ever offered on the template (see EventFees.tpl) when this
+      // participant has no contribution linked yet - it always creates a new one here. It does
+      // not, and should not, update an existing contribution - recording a payment against an
+      // existing Pending or Partially paid contribution is done via the 'Record Contribution'
+      // link to the Add Payment form (getContributionIDRequiringPayment()).
       if (!empty($params['record_contribution'])) {
         $contributionParams = [
           'skipLineItem' => 1,
@@ -1004,18 +965,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
           'card_type_id' => $this->getSubmittedValue('card_type_id'),
           'receive_date' => $this->getSubmittedValue('receive_date') ?: $now,
         ];
-        if (!empty($params['id'])) {
-          if ($this->_onlinePendingContributionId) {
-            $contributionParams['id'] = $this->_onlinePendingContributionId;
-          }
-          else {
-            $contributionParams['id'] = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_ParticipantPayment',
-              $params['id'],
-              'contribution_id',
-              'participant_id'
-            );
-          }
-        }
         unset($params['note']);
         $contributionParams['currency'] = $this->getCurrency();
         $contributionParams['contact_id'] = $this->_contactID;
@@ -1031,14 +980,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         if ($params['status_id'] == array_search('Partially paid', $participantStatus)) {
           if (!$amountOwed && $this->_action & CRM_Core_Action::UPDATE) {
             $amountOwed = $params['fee_amount'];
-          }
-
-          // if multiple participants are link, consider contribution total amount as the amount Owed
-          if ($this->_id && CRM_Event_BAO_Participant::isPrimaryParticipant($this->_id)) {
-            $amountOwed = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution',
-              $contributionParams['id'],
-              'total_amount'
-            );
           }
 
           // CRM-13964 partial payment
@@ -1258,7 +1199,20 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       }
 
       CRM_Core_Payment_Form::buildPaymentForm($form, $form->_paymentProcessor, FALSE, TRUE, self::getDefaultPaymentInstrumentId());
+      // This form does not support editing an existing contribution. On update, if no contribution
+      // is linked at all the normal record_contribution checkbox is still offered (there's nothing
+      // to conflict with). If one is linked and still requires payment (Pending or Partially paid)
+      // the template instead offers a 'Record Contribution' link to the Add Payment form.
+      $form->assign('isShowRecordPaymentLink', CRM_Core_Permission::access('CiviContribute')
+        && $this->_action == CRM_Core_Action::UPDATE
+        && (bool) $this->getContributionIDRequiringPayment()
+        && !$this->getParticipantValue('registered_by_id')
+      );
       if (!$form->_mode) {
+        $form->assign('isShowRecordContribution', CRM_Core_Permission::access('CiviContribute')
+          && ($this->_action != CRM_Core_Action::UPDATE || !$this->isPaymentOnExistingContribution())
+          && !$this->getParticipantValue('registered_by_id')
+        );
         $form->addElement('checkbox', 'record_contribution', ts('Record Payment?'), NULL,
           ['onclick' => "return showHideByValue('record_contribution','','payment_information','table-row','radio',false);"]
         );
@@ -1303,7 +1257,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     else {
       $form->add('text', 'amount', ts('Event Fee(s)'));
     }
-    $form->assign('onlinePendingContributionId', $form->get('onlinePendingContributionId'));
 
     $form->assign('paid', $form->_isPaidEvent ?? NULL);
 
@@ -1552,7 +1505,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * Is a payment being made on an existing contribution.
    *
    * Note
-   * 1) ideally we should not permit this on this form! Perhaps we don't & this is just cruft.
+   * 1) this form does not permit altering fees, or an existing contribution's payment, when
+   *    a contribution is already linked - see getContributionIDRequiringPayment() and
+   *    'Record Contribution' in EventFees.tpl, which route to the Add Payment form instead.
    * 2) _paymentID is the contribution id.
    *
    * @return bool
@@ -1588,6 +1543,25 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   }
 
   /**
+   * Get the id of a Pending or Partially paid contribution linked to this participant, if any.
+   *
+   * This form does not support altering an existing contribution - if the linked
+   * contribution still requires payment the user is instead offered a link to the
+   * Add Payment form (see 'Record Contribution' in EventFees.tpl).
+   *
+   * @return int|null
+   * @throws \CRM_Core_Exception
+   */
+  protected function getContributionIDRequiringPayment(): ?int {
+    $contributionID = $this->getExistingContributionID();
+    if (!$contributionID) {
+      return NULL;
+    }
+    $status = $this->lookup('ExistingContribution', 'contribution_status_id:name');
+    return in_array($status, ['Pending', 'Partially paid'], TRUE) ? $contributionID : NULL;
+  }
+
+  /**
    * Get id of participant being edited.
    *
    * @return int|null
@@ -1602,7 +1576,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   public function getParticipantID(): ?int {
     if ($this->_id === NULL) {
-      $id = CRM_Utils_Request::retrieve('id', 'Positive');
+      $id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
       $this->_id = $id ? (int) $id : FALSE;
     }
     return $this->_id ?: NULL;

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -52,7 +52,7 @@
       </tr>
     {/if}
 
-    {if $accessContribution and ! $participantMode and ($action neq 2 or !$rows.0.contribution_id or $onlinePendingContributionId) and $isRecordPayment and ! $registeredByParticipantId}
+    {if $isShowRecordContribution and $isRecordPayment}
       {assign var=isShowBillingBlock value=true}
         <tr class="crm-event-eventfees-form-block-record_contribution">
             <td class="label">{$form.record_contribution.label}</td>
@@ -80,6 +80,15 @@
            </fieldset>
            </td>
         </tr>
+    {/if}
+
+    {if $isShowRecordPaymentLink}
+      <tr class="crm-event-eventfees-form-block-record_contribution">
+        <td class="label"></td>
+        <td>
+          <a class="crm-hover-button action-item crm-popup" href='{crmURL p="civicrm/payment" q="reset=1&id=`$participantId`&cid=`$contactId`&action=add&component=event"}'><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i> {ts}Add Payment{/ts}</a>
+        </td>
+      </tr>
     {/if}
     </table>
 
@@ -191,36 +200,6 @@
 </script>
 {/if}
 
-{if $onlinePendingContributionId}
-<script type="text/javascript">
-{literal}
-  function confirmStatus( pStatusId, cStatusId ) {
-     if ( (pStatusId == cj("#status_id").val() ) && (cStatusId == cj("#contribution_status_id").val()) ) {
-         var allow = confirm( '{/literal}{ts escape='js'}The Payment Status for this participant is Completed. The Participant Status is set to Pending (pay later). Click Cancel if you want to review or modify these values before saving this record{/ts}{literal}.' );
-         if ( !allow ) return false;
-     }
-  }
-
-  function checkCancelled( statusId, pStatusId, cStatusId ) {
-    //selected participant status is 'cancelled'
-    if ( statusId == pStatusId ) {
-       cj("#contribution_status_id").val( cStatusId );
-
-       //unset value for send receipt check box.
-       cj("#send_receipt").prop("checked", false );
-       cj("#send_confirmation_receipt").hide( );
-
-       // set receive data to null.
-       clearDateTime( 'receive_date' );
-    } else {
-       cj("#send_confirmation_receipt").show( );
-    }
-    sendNotification();
-  }
-
-{/literal}
-</script>
-{/if}
 {if $showFeeBlock && $feeBlockPaid && ! $priceSet && $action neq 2}
 <script>
 {literal}


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6745 Use payment form to add payments to pending event

Before
----------------------------------------
If an event registration has a contribution that is not fully paid then the record_contribution button will appear provided
1) the contribution status is pending and 
2) the contribution was created from a front end form (determined by a text string in the contribution source)

nothing will appear if it is back office or otherwise created or if it is partially paid.

The code supporting this is very legacy and hard to maintain

From a user POV the process for ALL other updates of pending or partially paid contribution records is to update the contribution - which also works here. This does not add to the experience

After
----------------------------------------
Checkbox replaced by a link to add a payment - link appears for pending and partially paid and regardless of how the pending contribution was created

<img width="1198" height="696" alt="image" src="https://github.com/user-attachments/assets/d8a91c4b-df5f-4191-af8f-c0c8b0470d69" />


Technical Details
----------------------------------------

Comments
----------------------------------------
