### PR TITLE
Make |print_array smarty modifier support JSON

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.print_array.php
+++ b/CRM/Core/Smarty/plugins/modifier.print_array.php
@@ -78,6 +78,11 @@ function smarty_modifier_print_array($var, $depth = 0, $length = 40) {
       break;
 
     case 'string':
+      $decoded = json_decode($var, true);
+      if (is_array($decoded)) {
+        $results = json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        break;
+      }
       if (strlen($var) > $length) {
         $results = substr($var, 0, $length - 3) . '...';
       }


### PR DESCRIPTION
To use this in SearchKit, you'll want to Allow HTML, then do something like:

```<pre>{$field|print_array}</pre>```

to get a readable version of your JSON.

You can't use ```{[field]|print_array}```, because that's already a string.