### PR TITLE
Riverlea - make the active tab visible in Minetta and Hackney Brook dark mode

### DIFF
--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -47,6 +47,7 @@
   --crm-form-checkbox-list-bg-color: #665800;
 /* Tabs '--crm-tabs' */
   --crm-tab-bg-active: var(--crm-layer1-bg-color);
+  --crm-tab-bg-color: transparent; /* otherwise inactive tabs share the active fill */
 /* Contact layout '--crm-contact-' */
   --crm-contact-header-bg-color: transparent;
   --crm-contact-tab-hover-bg-color: var(--crm-layer1-bg-color);

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -15,6 +15,8 @@
   --crm-link-hover-color: var(--crm-c-yellow);
 /* Backgrounds, '--crm-c-*-bg' */
   --crm-container-bg-color: var(--crm-c-gray-800);
+/* Tabs '--crm-tabs' */
+  --crm-tab-bg-color: transparent; /* container-bg matches the active tab in dark, so let inactive tabs show the strip */
   --crm-inverse-bg-color: var(--crm-c-gray-300);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
   --crm-primary-color: var(--crm-c-gray-500);


### PR DESCRIPTION
Overview
----------------------------------------
In dark mode both streams resolve `--crm-tab-bg-color` and `--crm-tab-bg-active` to the same colour (Minetta #464646, Hackney #3b3b3b), and `--crm-tab-active-border` and `--crm-tab-hang` are both empty, so every Bootstrap tab strip - FormBuilder listing, APIv3 explorer, message templates, Afform tab sets - showed no current tab at all.

Setting the inactive fill transparent lets those tabs show the strip behind them and the active one keep the panel colour, which is how Thames already does it. Light mode is untouched.

Before
----------------------------------------
 Minetta dark: active rgb(70,70,70), inactive rgb(70,70,70) indistinguishable:
<img width="1240" height="88" alt="download" src="https://github.com/user-attachments/assets/9bb3bddf-2ecc-4a1f-8426-21b8aedf1251" />

Hackney dark: both rgb(59,59,59):
<img width="1240" height="88" alt="download" src="https://github.com/user-attachments/assets/13ec1370-667d-46cc-8270-1f6ad66100f3" />

After
----------------------------------------
Minetta dark:  active rgb(70,70,70), inactive transparent over strip rgb(83,82,82):
<img width="1240" height="88" alt="download" src="https://github.com/user-attachments/assets/fc1e5e84-7497-49f2-9210-7b6ca1bd3d5f" />

Hackney dark: active rgb(59,59,59), inactive transparent:
<img width="1240" height="88" alt="download" src="https://github.com/user-attachments/assets/4b3ab2e8-95ec-43f3-a7ab-bef2095e7aa3" />

Technical Details
----------------------------------------


Comments
----------------------------------------
@vingle 