### PR TITLE
Use native structuredClone() in the API Explorers instead of lodash cloneDeep

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -34,6 +34,7 @@
     "URLSearchParams",
     "TextEncoder",
     "crypto",
+    "structuredClone",
     "CSSStyleSheet",
     "Event",
     "HTMLElement",

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -171,7 +171,7 @@
       const actionInfo = entityInfo.actions.find((a) => a && a.name === action);
       // Avoid crash before metadata has been fetched
       if (actionInfo) {
-        const fieldInfo = _.cloneDeep(actionInfo.fields);
+        const fieldInfo = structuredClone(actionInfo.fields);
         if (addPseudoconstant) {
           addPseudoconstants(fieldInfo);
         }
@@ -187,11 +187,11 @@
       // Add entities specified by the join param
       Object.values(getExplicitJoins()).forEach(join => {
         let wildCard = addWildcard ? [{id: join.alias + '.*', text: join.alias + '.*', 'description': 'All core ' + join.entity + ' fields'}] : [],
-          joinFields = _.cloneDeep(entityFields(join.entity));
+          joinFields = structuredClone(entityFields(join.entity));
         if (joinFields) {
           // Add fields from bridge entity
           if (join.bridge) {
-            const bridgeFields = _.cloneDeep(entityFields(join.bridge)),
+            const bridgeFields = structuredClone(entityFields(join.bridge)),
               bridgeEntity = getEntity(join.bridge),
               joinFieldNames = joinFields.map((f) => f.name),
               // Check if this is a symmetric bridge e.g. RelationshipCache joins Contact to Contact
@@ -222,7 +222,7 @@
       // Add implicit joins based on schema links
       Object.values(entityFields($scope.entity, $scope.action)).forEach((field) => {
         if (field?.fk_entity) {
-          let linkFields = _.cloneDeep(entityFields(field.fk_entity)) ?? [],
+          let linkFields = structuredClone(entityFields(field.fk_entity)) ?? [],
             wildCard = addWildcard ? [{id: field.name + '.*', text: field.name + '.*', 'description': 'All core ' + field.fk_entity + ' fields'}] : [];
           if (addPseudoconstant) {
             addPseudoconstants(linkFields);
@@ -258,7 +258,7 @@
         const fkNameField = field?.fk_entity && getField('name', field.fk_entity, $scope.action);
 
         if (fkNameField && !field.name.includes(':')) {
-          const newField = _.cloneDeep(fkNameField);
+          const newField = structuredClone(fkNameField);
           newField.name = field.name + '.' + newField.name;
           // Insert new field after the current one
           fieldList.splice(pos + 1, 0, newField);
@@ -300,7 +300,7 @@
           see[idx] = '<a target="' + (ref[0] === '#' ? '_self' : '_blank') + '" href="' + ref + '">' + see[idx] + '</a>';
         });
       }
-      const formatted = _.cloneDeep(rawContent);
+      const formatted = structuredClone(rawContent);
       if (formatted.description) {
         formatted.description = marked(formatted.description);
       }
@@ -468,7 +468,7 @@
         if (params[key]) {
           const newParam = {};
           Object.values(params[key]).forEach((item) => {
-            let val = _.cloneDeep(item[1]);
+            let val = structuredClone(item[1]);
             // Remove blank items from "chain" array
             if (Array.isArray(val)) {
               item[1].slice().reverse().some((v) => {
@@ -567,7 +567,7 @@
 
         Object.entries(actionInfo.params || {}).forEach(([name, param]) => {
           let format;
-          let defaultVal = _.cloneDeep(param.default);
+          let defaultVal = structuredClone(param.default);
 
           if (param.type) {
             switch (param.type[0]) {
@@ -685,7 +685,7 @@
                 } else if (typeof objectParams[name] === 'undefined') {
                   $scope.params[name].push(field);
                 } else {
-                  const defaultOp = _.cloneDeep(objectParams[name]);
+                  const defaultOp = structuredClone(objectParams[name]);
 
                   if (name === 'chain') {
                     const num = $scope.params.chain.length;
@@ -962,7 +962,7 @@ apiCalls.${results} = [${jsCall}];
       const info = getEntity(entity),
         arrayParams = ['groupBy', 'records'],
         newLine = "\n" + _.repeat(' ', indent),
-        args = _.cloneDeep(info.class_args || []);
+        args = structuredClone(info.class_args || []);
       let code = '\\' + info.class + '::' + action + '(';
       // Always shows implicit true permissions check for PHP
       args.push(params.checkPermissions !== false);
@@ -1683,7 +1683,7 @@ apiCalls.${results} = [${jsCall}];
     const [baseFieldName, suffix] = fieldName.split(':');
     const fieldNames = baseFieldName.split('.');
 
-    const field = _.cloneDeep(get(entity, fieldNames));
+    const field = structuredClone(get(entity, fieldNames));
 
     if (field && suffix) {
       field.pseudoconstant = suffix;

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -110,7 +110,7 @@
   function getField(name) {
     var field = {};
     if (name && getFieldData[name]) {
-      field = _.cloneDeep(getFieldData[name]);
+      field = structuredClone(getFieldData[name]);
     } else if (name) {
       var ent = entity,
         act = action,
@@ -124,7 +124,7 @@
         prefix += (prefix.length ? '.' : '') + piece;
       });
       if (getFieldsCache[ent+act].values[name]) {
-        field = _.cloneDeep(getFieldsCache[ent+act].values[name]);
+        field = structuredClone(getFieldsCache[ent+act].values[name]);
       }
     }
     addJoinInfo(field, name);
@@ -293,7 +293,7 @@
           return ret;
         }, {})
       };
-      getFieldsCache[entity+action] = {values: _.cloneDeep(getFieldData)};
+      getFieldsCache[entity+action] = {values: structuredClone(getFieldData)};
       showFields(['api_action']);
       renderJoinSelector();
       return;
@@ -859,7 +859,7 @@
             };
           }
         });
-      })(_.cloneDeep(getFieldData), joinable, '', 1, [entity]);
+      })(structuredClone(getFieldData), joinable, '', 1, [entity]);
       if (!_.isEmpty(joinable)) {
         // Send joinTpl as a param so it can recursively call itself to render children
         $('#api-join').show().children('div').html(joinTpl({joins: joinable, tpl: joinTpl}));


### PR DESCRIPTION
Overview
----------------------------------------

Replaces lodash's `_.cloneDeep()` with the browser-native `structuredClone()` in the APIv4 and APIv3 Explorer screens, as part of the ongoing removal of lodash from core JavaScript.

Before
----------------------------------------

Both Explorers deep-clone API metadata through lodash:

```js
const fieldInfo = _.cloneDeep(actionInfo.fields);
```

15 call sites in total — 11 in `ang/api4Explorer/Explorer.js` and 4 in `templates/CRM/Admin/Page/APIExplorer.js`.

After
----------------------------------------

The same clones use the native function, with no other change to the surrounding logic:

```js
const fieldInfo = structuredClone(actionInfo.fields);
```

No user-visible change — the Explorers behave exactly as before.

Technical Details
----------------------------------------

`structuredClone()` is not a blanket substitute for `_.cloneDeep()`: lodash passes functions held as object properties through by reference, whereas `structuredClone()` throws
`DataCloneError` if a function appears anywhere in the graph. That makes it lue is known to be plain data.

Every value cloned in these two files is API metadata decoded from a `getFiearrays, plain objects, strings, numbers, booleans — so all 15 sites qualify.Three of them can legitimately receive `undefined` (an entity with no metadata, a param with no default, a field lookup that misses); `structuredClone(undefined)` returns `undefined` just as lodash does, so the `?? []` and truthiness guards downstream are unaffected.

`.jshintrc` gains `structuredClone` in its `predef` list, since that file uses an explicit global allowlist rather than `browser: true`.

Comments
----------------------------------------

Tested manually against a Standalone build:

- **APIv4 Explorer, `Contact::get`** — field list including implicit `address_primary.*` joins; an explicit `Tag AS tag` join through the `EntityTag` bridge, correctly surfacing
bridge fields such as `tag.entity_table`; the documentation panel with its rnks; a where clause with pseudoconstant options; `orderBy` picking up its`ASC` default; the generated PHP (OOP and traditional); executing the call and getting results back.
- **APIv4 Explorer, `Contact::create`** — write-join fields (`address_primary.name`, `im_primary.name`) still generated.
- **APIv3 Explorer, `Contact.get`** — parameter widget, "Fields to return", and executing the call.

No console errors in any of the above. Both files are `civilint` clean.

This overlaps with #36703 only in the one-line `.jshintrc` addition, which t conflict for whichever merges second. Otherwise the two are independent andthis one can go in on its own.