### PR TITLE
Use native structuredClone() in afform instead of lodash cloneDeep

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -34,6 +34,7 @@
     "URLSearchParams",
     "TextEncoder",
     "crypto",
+    "structuredClone",
     "CSSStyleSheet",
     "Event",
     "HTMLElement",

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -171,7 +171,7 @@
       const actionInfo = entityInfo.actions.find((a) => a && a.name === action);
       // Avoid crash before metadata has been fetched
       if (actionInfo) {
-        const fieldInfo = _.cloneDeep(actionInfo.fields);
+        const fieldInfo = structuredClone(actionInfo.fields);
         if (addPseudoconstant) {
           addPseudoconstants(fieldInfo);
         }
@@ -187,11 +187,11 @@
       // Add entities specified by the join param
       Object.values(getExplicitJoins()).forEach(join => {
         let wildCard = addWildcard ? [{id: join.alias + '.*', text: join.alias + '.*', 'description': 'All core ' + join.entity + ' fields'}] : [],
-          joinFields = _.cloneDeep(entityFields(join.entity));
+          joinFields = structuredClone(entityFields(join.entity));
         if (joinFields) {
           // Add fields from bridge entity
           if (join.bridge) {
-            const bridgeFields = _.cloneDeep(entityFields(join.bridge)),
+            const bridgeFields = structuredClone(entityFields(join.bridge)),
               bridgeEntity = getEntity(join.bridge),
               joinFieldNames = joinFields.map((f) => f.name),
               // Check if this is a symmetric bridge e.g. RelationshipCache joins Contact to Contact
@@ -222,7 +222,7 @@
       // Add implicit joins based on schema links
       Object.values(entityFields($scope.entity, $scope.action)).forEach((field) => {
         if (field?.fk_entity) {
-          let linkFields = _.cloneDeep(entityFields(field.fk_entity)) ?? [],
+          let linkFields = structuredClone(entityFields(field.fk_entity)) ?? [],
             wildCard = addWildcard ? [{id: field.name + '.*', text: field.name + '.*', 'description': 'All core ' + field.fk_entity + ' fields'}] : [];
           if (addPseudoconstant) {
             addPseudoconstants(linkFields);
@@ -258,7 +258,7 @@
         const fkNameField = field?.fk_entity && getField('name', field.fk_entity, $scope.action);
 
         if (fkNameField && !field.name.includes(':')) {
-          const newField = _.cloneDeep(fkNameField);
+          const newField = structuredClone(fkNameField);
           newField.name = field.name + '.' + newField.name;
           // Insert new field after the current one
           fieldList.splice(pos + 1, 0, newField);
@@ -300,7 +300,7 @@
           see[idx] = '<a target="' + (ref[0] === '#' ? '_self' : '_blank') + '" href="' + ref + '">' + see[idx] + '</a>';
         });
       }
-      const formatted = _.cloneDeep(rawContent);
+      const formatted = structuredClone(rawContent);
       if (formatted.description) {
         formatted.description = marked(formatted.description);
       }
@@ -468,7 +468,7 @@
         if (params[key]) {
           const newParam = {};
           Object.values(params[key]).forEach((item) => {
-            let val = _.cloneDeep(item[1]);
+            let val = structuredClone(item[1]);
             // Remove blank items from "chain" array
             if (Array.isArray(val)) {
               item[1].slice().reverse().some((v) => {
@@ -567,7 +567,7 @@
 
         Object.entries(actionInfo.params || {}).forEach(([name, param]) => {
           let format;
-          let defaultVal = _.cloneDeep(param.default);
+          let defaultVal = structuredClone(param.default);
 
           if (param.type) {
             switch (param.type[0]) {
@@ -685,7 +685,7 @@
                 } else if (typeof objectParams[name] === 'undefined') {
                   $scope.params[name].push(field);
                 } else {
-                  const defaultOp = _.cloneDeep(objectParams[name]);
+                  const defaultOp = structuredClone(objectParams[name]);
 
                   if (name === 'chain') {
                     const num = $scope.params.chain.length;
@@ -962,7 +962,7 @@ apiCalls.${results} = [${jsCall}];
       const info = getEntity(entity),
         arrayParams = ['groupBy', 'records'],
         newLine = "\n" + _.repeat(' ', indent),
-        args = _.cloneDeep(info.class_args || []);
+        args = structuredClone(info.class_args || []);
       let code = '\\' + info.class + '::' + action + '(';
       // Always shows implicit true permissions check for PHP
       args.push(params.checkPermissions !== false);
@@ -1683,7 +1683,7 @@ apiCalls.${results} = [${jsCall}];
     const [baseFieldName, suffix] = fieldName.split(':');
     const fieldNames = baseFieldName.split('.');
 
-    const field = _.cloneDeep(get(entity, fieldNames));
+    const field = structuredClone(get(entity, fieldNames));
 
     if (field && suffix) {
       field.pseudoconstant = suffix;

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -190,7 +190,7 @@
         // Initialize undo history
         undoAction = 'initialLoad';
         undoHistory = [{
-          afform: _.cloneDeep(editor.afform),
+          afform: structuredClone(editor.afform),
           saved: editor.mode === 'edit',
           selectedEntityName: null
         }];
@@ -202,7 +202,7 @@
               undoPosition = 0;
             }
             undoHistory.unshift({
-              afform: _.cloneDeep(editor.afform),
+              afform: structuredClone(editor.afform),
               saved: false,
               selectedEntityName: $scope.selectedEntityName
             });
@@ -240,7 +240,7 @@
         }
         undoPosition += direction;
         undoAction = 'change';
-        editor.afform = _.cloneDeep(undoHistory[undoPosition].afform);
+        editor.afform = structuredClone(undoHistory[undoPosition].afform);
         syncAfformTagIds();
         setEditorLayout();
         editor.canvasTab = 'layout';
@@ -404,12 +404,12 @@
           editor.layout['#children'].splice(pos, 0, $scope.entities[type + num]);
           // Create a new af-fieldset container for the entity
           if (meta.boilerplate !== false) {
-            const fieldset = _.cloneDeep(afGui.meta.elements.fieldset.element);
+            const fieldset = structuredClone(afGui.meta.elements.fieldset.element);
             fieldset['af-fieldset'] = type + num;
             fieldset['af-title'] = meta.label + ' ' + num;
             // Add boilerplate contents if any
             if (Array.isArray(meta.boilerplate) && meta.boilerplate.length) {
-              fieldset['#children'].push(..._.cloneDeep(meta.boilerplate));
+              fieldset['#children'].push(...structuredClone(meta.boilerplate));
             }
             // Attempt to place the new af-fieldset after the last one on the form
             pos = 1 + _.findLastIndex(editor.layout['#children'], 'af-fieldset');
@@ -613,7 +613,7 @@
 
       // Gets complete field defn, merging values from the field with default values
       function fillFieldDefn(entityType, field) {
-        const spec = _.cloneDeep(afGui.getField(entityType, field.name));
+        const spec = structuredClone(afGui.getField(entityType, field.name));
         return _.merge(spec, field.defn || {});
       }
 

--- a/ext/afform/admin/ang/afGuiEditor/afGuiElements.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiElements.component.js
@@ -46,7 +46,7 @@
         function addExtraField(field) {
           const tag = {
             "#tag": "af-field",
-            defn: _.cloneDeep(field.extra_defn),
+            defn: structuredClone(field.extra_defn),
           };
           tag.defn.label = ts('Extra %1', {1: field.label});
           tag.defn.input_type = field.name;
@@ -77,7 +77,7 @@
             (!element.afform_type || element.afform_type.includes(formType)) &&
             name !== 'fieldset' && // Only shown on afGuiEntity tab
             (!search || name.includes(search) || element.title.toLowerCase().includes(search))) {
-            const node = _.cloneDeep(element.element);
+            const node = structuredClone(element.element);
             $scope.elementList.push(node);
             $scope.elementTitles.push(element.title);
           }

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -230,7 +230,7 @@
           ctrl.editor.allowEntityConfig &&
           (!search || fieldsetTitle.toLowerCase().includes(search))
         ) {
-          const fieldsetElement = _.cloneDeep(afGui.meta.elements.fieldset.element);
+          const fieldsetElement = structuredClone(afGui.meta.elements.fieldset.element);
           fieldsetElement['af-fieldset'] = ctrl.entity.name;
           $scope.elementList.push(fieldsetElement);
           $scope.elementTitles.push(fieldsetTitle);
@@ -332,7 +332,7 @@
 
         const behaviorInfo = CRM.afGuiEditor.behaviors[ctrl.getEntityType()] || [];
         ctrl.behaviors = behaviorInfo.reduce((behaviors, behavior) => {
-          const item = _.cloneDeep(behavior);
+          const item = structuredClone(behavior);
           item.options = formatForSelect2(item.modes, 'name', 'label', ['description', 'icon']);
           behaviors.push(item);
           return behaviors;

--- a/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemStyle.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemStyle.component.js
@@ -12,7 +12,7 @@
       const ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
         ctrl = this;
 
-      this.styles = _.cloneDeep(afGui.meta.afform_container_style);
+      this.styles = structuredClone(afGui.meta.afform_container_style);
 
       $scope.getSetStyle = function(style) {
         const options = ctrl.styles.map(item => item.value);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -72,7 +72,7 @@
       function buildCalcFieldList(search) {
         $scope.calcFieldList.length = 0;
         $scope.calcFieldTitles.length = 0;
-        _.each(_.cloneDeep(ctrl.display.settings.calc_fields), function(field) {
+        _.each(structuredClone(ctrl.display.settings.calc_fields), function(field) {
           if (!search || field.label.toLowerCase().includes(search)) {
             $scope.calcFieldList.push(fieldDefaults(field, ''));
             $scope.calcFieldTitles.push(field.label);

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -265,7 +265,7 @@
 
       $scope.selectBlockDirective = function() {
         if (block.directive) {
-          block.layout = _.cloneDeep(afGui.meta.blocks[block.directive].layout);
+          block.layout = structuredClone(afGui.meta.blocks[block.directive].layout);
           block.original = block.directive;
           setBlockDirective(block.directive);
         }
@@ -310,7 +310,7 @@
 
         if (getBlockNode() && getBlockNode()['#tag'] in afGui.meta.blocks) {
           block.directive = block.original = getBlockNode()['#tag'];
-          block.layout = _.cloneDeep(afGui.meta.blocks[block.directive].layout);
+          block.layout = structuredClone(afGui.meta.blocks[block.directive].layout);
         }
 
         block.listeners.push($scope.$watch('block.layout', function (layout, oldVal) {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -33,7 +33,7 @@
       this.$onInit = function() {
         ctrl.hasDefaultValue = !!getSet('afform_default');
         setFieldDefn();
-        ctrl.inputTypes = _.transform(_.cloneDeep(afGui.meta.inputTypes), function(inputTypes, type) {
+        ctrl.inputTypes = _.transform(structuredClone(afGui.meta.inputTypes), function(inputTypes, type) {
           type.enabled = inputTypeCanBe(type.name);
           // Change labels for EntityRef fields
           if (ctrl.getDefn().input_type === 'EntityRef') {
@@ -158,7 +158,7 @@
           // Extra (non-entity) field: seed from the inputType's extra_defn
           const inputType = afGui.meta.inputTypes.find((t) => t.name === ctrl.node.defn.input_type);
           if (inputType?.extra_defn) {
-            defn = _.cloneDeep(inputType.extra_defn);
+            defn = structuredClone(inputType.extra_defn);
           }
         }
         defn = defn || {
@@ -166,7 +166,7 @@
           required: false
         };
         // Clone to prevent mutating shared metadata objects
-        defn = _.cloneDeep(defn);
+        defn = structuredClone(defn);
         if (_.isEmpty(defn.input_attrs)) {
           defn.input_attrs = {};
         }

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -239,7 +239,7 @@
             if (ctrl.defn.is_date) {
               ctrl.inputAttrs.push(ctrl.defn.input_attrs || {});
               for (let i = 1; i <= 2; ++i) {
-                const attrs = _.cloneDeep(ctrl.defn.input_attrs || {});
+                const attrs = structuredClone(ctrl.defn.input_attrs || {});
                 attrs.placeholder = attrs['placeholder' + i];
                 attrs.timePlaceholder = attrs['timePlaceholder' + i];
                 ctrl.inputAttrs.push(attrs);

--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -127,7 +127,7 @@
           };
 
           // get a copy of the object
-          const data = _.cloneDeep(this.getFieldData());
+          const data = structuredClone(this.getFieldData());
 
           Object.keys(data).forEach((key) => {
             // first filter sub objects

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -116,7 +116,7 @@
                 _.each(item.values, (values, index) => {
                   data[item.name][index] = data[item.name][index] || {};
                   data[item.name][index].joins = data[item.name][index].joins || {};
-                  angular.merge(data[item.name][index], values, {fields: _.cloneDeep(schema[item.name]?.data || {})});
+                  angular.merge(data[item.name][index], values, {fields: structuredClone(schema[item.name]?.data || {})});
                 });
               });
               $element.unblock();
@@ -134,7 +134,7 @@
           // Delete object keys without breaking object references
           Object.keys(data[selectedEntity][selectedIndex].fields).forEach((key) => delete data[selectedEntity][selectedIndex].fields[key]);
           // Fill pre-set values
-          angular.merge(data[selectedEntity][selectedIndex].fields, _.cloneDeep(schema[selectedEntity].data || {}));
+          angular.merge(data[selectedEntity][selectedIndex].fields, structuredClone(schema[selectedEntity].data || {}));
           data[selectedEntity][selectedIndex].joins = {};
         }
       };

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -110,7 +110,7 @@
   function getField(name) {
     var field = {};
     if (name && getFieldData[name]) {
-      field = _.cloneDeep(getFieldData[name]);
+      field = structuredClone(getFieldData[name]);
     } else if (name) {
       var ent = entity,
         act = action,
@@ -124,7 +124,7 @@
         prefix += (prefix.length ? '.' : '') + piece;
       });
       if (getFieldsCache[ent+act].values[name]) {
-        field = _.cloneDeep(getFieldsCache[ent+act].values[name]);
+        field = structuredClone(getFieldsCache[ent+act].values[name]);
       }
     }
     addJoinInfo(field, name);
@@ -293,7 +293,7 @@
           return ret;
         }, {})
       };
-      getFieldsCache[entity+action] = {values: _.cloneDeep(getFieldData)};
+      getFieldsCache[entity+action] = {values: structuredClone(getFieldData)};
       showFields(['api_action']);
       renderJoinSelector();
       return;
@@ -859,7 +859,7 @@
             };
           }
         });
-      })(_.cloneDeep(getFieldData), joinable, '', 1, [entity]);
+      })(structuredClone(getFieldData), joinable, '', 1, [entity]);
       if (!_.isEmpty(joinable)) {
         // Send joinTpl as a param so it can recursively call itself to render children
         $('#api-join').show().children('div').html(joinTpl({joins: joinable, tpl: joinTpl}));


### PR DESCRIPTION
Overview
----------------------------------------

Replaces lodash's `_.cloneDeep()` with the browser-native `structuredClone()` throughout afform's Angular code, as part of the ongoing removal of lodash from core JavaScript.

Stacked on #36764 — please review that one first. This branch only adds the afform commit on top; the `.jshintrc` change belongs to #36764.

Before
----------------------------------------

21 call sites across afform's admin and core modules deep-clone through lodash:

```js
undoHistory = [{
  afform: _.cloneDeep(editor.afform),
  saved: editor.mode === 'edit',
  selectedEntityName: null
}];
```

After
----------------------------------------

The same clones use the native function, with no other change to the surrounding logic:

```js
undoHistory = [{
  afform: structuredClone(editor.afform),
  saved: editor.mode === 'edit',
  selectedEntityName: null
}];
```

No user-visible change.

Technical Details
----------------------------------------

`structuredClone()` is not a blanket substitute for `_.cloneDeep()`: lodash passes functions held as object properties through by reference, whereas `structuredClone()` throws `DataCloneError` if a function appears anywhere in the graph. It is only safe where the cloned value is known to be plain data.

All 21 sites qualify, in three categories:

- **Editor metadata** — `afGui.meta.*`, `afGui.getField()` and `CRM.afGuiEditor.behaviors` all resolve to `CRM.afGuiEditor` / `CRM.afAdmin`, which PHP injects via `addVars` (see `ang/afGuiEditor.js`). JSON by construction.
- **The form definition** — `editor.afform` and the layout nodes beneath it, as loaded by `Afform.get` and edited in the browser.
- **Runtime values** — field `defn` objects, `input_attrs`, and submitted field values. Uploaded files are handled by a separate `FileUploader` and never enter the field data.

Worth noting the undo history clones the entire form definition on every edit, so this path also gets slightly cheaper.

Comments
----------------------------------------

Tested manually against a Standalone build, with no console errors at any point.

FormBuilder editor:

- New Individual submission form — fieldset and boilerplate fields generated correctly.
- Added a second (Organization) entity — new fieldset plus its boilerplate.
- Elements and Extra Fields palettes both populate.
- Field settings panel (input types, style, max length).
- Container settings menu, including the Style dropdown.
- **Undo** — round-trips the cloned form definition and re-renders the canvas intact. This is the most heavily exercised of the 21 sites.

Rendered forms:

- Custom Field Groups search form — typing a filter narrowed 3 results to 1, exercising `getFilterValues()`.
- Mailings search form — "Choose Date Range" on Created Date rendered both date/time picker pairs (the `input_attrs` clone), and picking a date correctly re-ran the search.

All 10 changed files are `civilint` clean.