### PR TITLE
Accessibility/tabs: Put role=tab on the focusable tab, not the list item

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -202,8 +202,8 @@
     <div class="panel panel-info explorer-code-panel">
       <div class="panel-heading">
         <ul role="tablist" class="nav nav-tabs">
-          <li role="tab" ng-repeat="lang in ::langs" ng-class="{active: selectedTab.code === lang}">
-            <a href ng-click="selectLang(lang)">
+          <li role="presentation" ng-repeat="lang in ::langs" ng-class="{active: selectedTab.code === lang}">
+            <a href role="tab" aria-selected="{{ selectedTab.code === lang }}" ng-click="selectLang(lang)">
               {{:: lang }}
             </a>
           </li>
@@ -255,8 +255,8 @@
           </select>
         </div>
         <ul role="tablist" class="nav nav-tabs">
-          <li role="tab" ng-class="{active: selectedTab.result === 'result'}">
-            <a href ng-click="selectedTab.result = 'result'">
+          <li role="presentation" ng-class="{active: selectedTab.result === 'result'}">
+            <a href role="tab" aria-selected="{{ selectedTab.result === 'result' }}" ng-click="selectedTab.result = 'result'">
               <span ng-switch="status">
                 <i class="fa fa-fw fa-circle-o" ng-switch-when="default" role="img" aria-hidden="true"></i>
                 <i class="fa fa-fw fa-check-circle" ng-switch-when="success" role="img" aria-hidden="true"></i>
@@ -267,8 +267,8 @@
               <span>{{:: ts('Result') }}</span>
             </a>
           </li>
-          <li role="tab" ng-if="::perm.viewDebugOutput" ng-class="{active: selectedTab.result === 'debug'}">
-            <a href ng-click="selectedTab.result = 'debug'">
+          <li role="presentation" ng-if="::perm.viewDebugOutput" ng-class="{active: selectedTab.result === 'debug'}">
+            <a href role="tab" aria-selected="{{ selectedTab.result === 'debug' }}" ng-click="selectedTab.result = 'debug'">
               <i class="fa fa-fw fa-{{ debug ? (status === 'warning' || status === 'danger' ? 'warning' : 'bug') : 'circle-o' }}" role="img" aria-hidden="true"></i>
               <span>{{:: ts('Debug') }}</span>
             </a>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
@@ -28,14 +28,14 @@
     </div>
 
     <ul role="tablist" class="nav nav-tabs">
-      <li role="tab" ng-class="{active: editor.canvasTab === 'layout'}">
-        <a href ng-click="switchToLayoutTab()">
+      <li role="presentation" ng-class="{active: editor.canvasTab === 'layout'}">
+        <a href role="tab" aria-selected="{{ editor.canvasTab === 'layout' }}" ng-click="switchToLayoutTab()">
           <i class="crm-i fa-list-alt" role="img" aria-hidden="true"></i>
           <span>{{:: ts('Layout') }}</span>
         </a>
       </li>
-      <li role="tab" ng-class="{active: editor.canvasTab === 'markup'}">
-        <a href ng-click="editor.canvasTab = 'markup'; !editor.markupEditMode && updateLayoutHtml()">
+      <li role="presentation" ng-class="{active: editor.canvasTab === 'markup'}">
+        <a href role="tab" aria-selected="{{ editor.canvasTab === 'markup' }}" ng-click="editor.canvasTab = 'markup'; !editor.markupEditMode && updateLayoutHtml()">
           <i class="crm-i fa-code" role="img" aria-hidden="true"></i>
           <span>{{:: ts('Markup') }}</span>
         </a>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -1,34 +1,34 @@
 <div id="afGuiEditor-palette-config" class="panel panel-default">
   <div class="panel-heading">
     <ul id="afGuiEditor-palette-tabs" role="tablist" class="nav nav-tabs">
-      <li role="tab" class="fluid-width-tab" ng-class="{active: selectedEntityName === null}" title="{{:: ts('Form Settings') }}">
-        <a href ng-click="editor.selectEntity(null)">
+      <li role="presentation" class="fluid-width-tab" ng-class="{active: selectedEntityName === null}" title="{{:: ts('Form Settings') }}">
+        <a href role="tab" aria-selected="{{ selectedEntityName === null }}" ng-click="editor.selectEntity(null)">
           <i class="crm-i fa-gear" role="img" aria-hidden="true"></i>
           <span>{{:: ts('Settings') }}</span>
         </a>
       </li>
-      <li role="tab" class="fluid-width-tab" ng-class="{active: selectedEntityName === 'extra'}" title="{{:: ts('Elements') }}">
-        <a href ng-click="editor.selectEntity('extra')">
+      <li role="presentation" class="fluid-width-tab" ng-class="{active: selectedEntityName === 'extra'}" title="{{:: ts('Elements') }}">
+        <a href role="tab" aria-selected="{{ selectedEntityName === 'extra' }}" ng-click="editor.selectEntity('extra')">
           <i class="crm-i fa-rectangle-list" role="img" aria-hidden="true"></i>
           <span>{{:: ts('Elements') }}</span>
         </a>
       </li>
-      <li role="tab" ng-repeat="entity in entities" class="fluid-width-tab" ng-class="{active: selectedEntityName === entity.name}" title="{{ entity.label }}">
-        <a href ng-click="editor.selectEntity(entity.name); editor.scrollToEntity(entity.name);">
+      <li role="presentation" ng-repeat="entity in entities" class="fluid-width-tab" ng-class="{active: selectedEntityName === entity.name}" title="{{ entity.label }}">
+        <a href role="tab" aria-selected="{{ selectedEntityName === entity.name }}" ng-click="editor.selectEntity(entity.name); editor.scrollToEntity(entity.name);">
           <i class="crm-i {{:: editor.getEntityDefn(entity).icon }}" role="img" aria-hidden="true"></i>
           <span ng-if="!entity.loading && editor.allowEntityConfig && selectedEntityName === entity.name" crm-ui-editable ng-model="entity.label" ng-change="editor.adjustTabWidths()">{{ entity.label }}</span>
           <span ng-if="!entity.loading && !(editor.allowEntityConfig && selectedEntityName === entity.name)">{{ entity.label }}</span>
           <i ng-if="entity.loading" class="crm-i fa-spin fa-spinner" role="img" aria-hidden="true"></i>
         </a>
       </li>
-      <li role="tab" ng-repeat="(key, display) in editor.searchDisplays" class="fluid-width-tab" ng-class="{active: selectedEntityName === key}" title="{{ display.label }}">
-        <a href ng-click="display.settings && editor.selectEntity(key)">
+      <li role="presentation" ng-repeat="(key, display) in editor.searchDisplays" class="fluid-width-tab" ng-class="{active: selectedEntityName === key}" title="{{ display.label }}">
+        <a href role="tab" aria-selected="{{ selectedEntityName === key }}" ng-click="display.settings && editor.selectEntity(key)">
           <i ng-if="display.settings" class="crm-i {{:: display.settings['type:icon'] }}" role="img" aria-hidden="true"></i>
           <i ng-if="!display.settings" class="crm-i fa-spin fa-spinner" role="img" aria-hidden="true"></i>
           <span>{{ display.settings.label }}</span>
         </a>
       </li>
-      <li role="tab" class="dropdown" ng-if="editor.allowEntityConfig" title="{{:: ts('Add Entity') }}" af-gui-menu>
+      <li role="presentation" class="dropdown" ng-if="editor.allowEntityConfig" title="{{:: ts('Add Entity') }}" af-gui-menu>
         <a href class="dropdown-toggle" data-toggle="dropdown">
           <i class="crm-i fa-plus" role="img" aria-hidden="true"></i>
         </a>
@@ -41,7 +41,7 @@
           </li>
         </ul>
       </li>
-      <li role="tab" class="dropdown" ng-if="editor.getFormType() === 'search'" title="{{:: ts('Add Search') }}" af-gui-menu>
+      <li role="presentation" class="dropdown" ng-if="editor.getFormType() === 'search'" title="{{:: ts('Add Search') }}" af-gui-menu>
         <a href class="dropdown-toggle" data-toggle="dropdown" ng-click="editor.getSearchDisplaySelector();">
           <i class="crm-i fa-plus" role="img" aria-hidden="true"></i>
         </a>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.html
@@ -10,8 +10,8 @@
   </div>
 </div>
 <ul class="nav nav-tabs" role="tablist">
-  <li ng-repeat="(tabIndex, tab) in $ctrl.node['#children']" role="tab" class="dropdown" ng-class="{active: tabIndex === $ctrl.selectedTab}">
-    <a href ng-click="$ctrl.selectTab(tabIndex)">
+  <li ng-repeat="(tabIndex, tab) in $ctrl.node['#children']" role="presentation" class="dropdown" ng-class="{active: tabIndex === $ctrl.selectedTab}">
+    <a href role="tab" aria-selected="{{ tabIndex === $ctrl.selectedTab }}" ng-click="$ctrl.selectTab(tabIndex)">
       <i class="crm-i {{ tab.icon }}" ng-if="tab.icon" role="img" aria-hidden="true"></i>
       {{ tab['title'] }}
       <button class="btn btn-default btn-xs af-gui-add-element-button" data-tab-id="{{ tabIndex }}" ng-click="$ctrl.getSearchDisplays(tabIndex)">

--- a/ext/afform/core/ang/af/afTabset.html
+++ b/ext/afform/core/ang/af/afTabset.html
@@ -1,6 +1,6 @@
 <ul role="tablist" class="nav nav-tabs crm-tab-list">
-  <li ng-repeat="tab in $ctrl.tabs" role="tab" class="crm-tab-button" data-name="{{:: tab.name }}" ng-class="{active: tab.name === $ctrl.selectedTab}">
-    <a href ng-click="$ctrl.selectTab(tab.name)">
+  <li ng-repeat="tab in $ctrl.tabs" role="presentation" class="crm-tab-button" data-name="{{:: tab.name }}" ng-class="{active: tab.name === $ctrl.selectedTab}">
+    <a href role="tab" aria-selected="{{ tab.name === $ctrl.selectedTab }}" ng-click="$ctrl.selectTab(tab.name)">
       <i ng-if="tab.icon" class="crm-i {{ tab.icon }}" role="img" aria-hidden="true"></i>
       {{ tab.title }}
       <span class="badge">{{ tab.count }}</span>

--- a/ext/message_admin/ang/crmMsgadm/ListNav.html
+++ b/ext/message_admin/ang/crmMsgadm/ListNav.html
@@ -1,14 +1,14 @@
 <nav class="bg-info">
   <ul role="tablist" class="nav nav-tabs">
-    <li role="tab"
+    <li role="presentation"
         ng-class="{active: location.path() === '/user'}"
         ng-if="checkPerm('edit message templates') || checkPerm('edit user-driven message templates')">
-      <a ng-href="#/user">{{:: ts('User-Driven Messages') }}</a>
+      <a ng-href="#/user" role="tab" aria-selected="{{ location.path() === '/user' }}">{{:: ts('User-Driven Messages') }}</a>
     </li>
-    <li role="tab"
+    <li role="presentation"
         ng-class="{active: location.path() === '/workflow'}"
         ng-if="checkPerm('edit message templates') || checkPerm('edit system workflow message templates')">
-      <a ng-href="#/workflow">{{:: ts('System Workflow Messages' )}}</a>
+      <a ng-href="#/workflow" role="tab" aria-selected="{{ location.path() === '/workflow' }}">{{:: ts('System Workflow Messages' )}}</a>
     </li>
   </ul>
 </nav>

--- a/ext/oauth-client/ang/oauthProviderDetail.aff.html
+++ b/ext/oauth-client/ang/oauthProviderDetail.aff.html
@@ -5,9 +5,9 @@
 <div ng-if="!theClients.loading">
   <div class="panel panel-info" ng-init="selected = {tab: theClients.result.length > 0 ? 'client_' + theClients.result[0].id : 'new'}">
     <ul class="panel-heading nav nav-tabs">
-      <li role="tab" ng-repeat="theClient in theClients.result" ng-class="{active: selected.tab === 'client_' + theClient.id}"><a ng-click="selected.tab = 'client_' + theClient.id">{{ts('Client #%1', {1: theClient.id})}}</a></li>
-      <li role="tab" ng-class="{active: selected.tab === 'new'}"><a ng-click="selected.tab = 'new'">{{ts('Register Client')}}</a></li>
-      <li role="tab" ng-class="{active: selected.tab === 'details'}"><a ng-click="selected.tab = 'details'">{{ts('Details')}}</a></li>
+      <li role="presentation" ng-repeat="theClient in theClients.result" ng-class="{active: selected.tab === 'client_' + theClient.id}"><a role="tab" aria-selected="{{ selected.tab === 'client_' + theClient.id }}" ng-click="selected.tab = 'client_' + theClient.id">{{ts('Client #%1', {1: theClient.id})}}</a></li>
+      <li role="presentation" ng-class="{active: selected.tab === 'new'}"><a role="tab" aria-selected="{{ selected.tab === 'new' }}" ng-click="selected.tab = 'new'">{{ts('Register Client')}}</a></li>
+      <li role="presentation" ng-class="{active: selected.tab === 'details'}"><a role="tab" aria-selected="{{ selected.tab === 'details' }}" ng-click="selected.tab = 'details'">{{ts('Details')}}</a></li>
     </ul>
 
     <div role="tabpanel" class="panel-body" ng-if="selected.tab === 'details'">

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
@@ -4,8 +4,8 @@
   <!-- Tabs based on the has_base filter -->
   <div class="crm-search-nav-tabs">
     <ul role="tablist" class="nav nav-tabs">
-      <li ng-repeat="tab in $ctrl.tabs" role="tab" ng-class="{active: $ctrl.tab === tab.name}">
-        <a href ng-click="$ctrl.tab = tab.name"><i class="crm-i {{:: tab.icon }}" role="img" aria-hidden="true"></i>
+      <li ng-repeat="tab in $ctrl.tabs" role="presentation" ng-class="{active: $ctrl.tab === tab.name}">
+        <a href role="tab" aria-selected="{{ $ctrl.tab === tab.name }}" ng-click="$ctrl.tab = tab.name"><i class="crm-i {{:: tab.icon }}" role="img" aria-hidden="true"></i>
           {{:: tab.title }}
           <span class="badge">{{ tab.rowCount }}</span>
         </a>

--- a/ext/search_kit/ang/crmSearchAdmin/tabs.html
+++ b/ext/search_kit/ang/crmSearchAdmin/tabs.html
@@ -1,12 +1,12 @@
-<li role="tab" ng-class="{active: controls.tab === tab.key}" ng-repeat="tab in $ctrl.mainTabs">
-  <a href ng-click="selectTab(tab.key)">
+<li role="presentation" ng-class="{active: controls.tab === tab.key}" ng-repeat="tab in $ctrl.mainTabs">
+  <a href role="tab" aria-selected="{{ controls.tab === tab.key }}" ng-click="selectTab(tab.key)">
     <i class="crm-i {{:: tab.icon }}" role="img" aria-hidden="true"></i>
     {{:: tab.title }}
   </a>
 </li>
 <li role="separator" class="disabled"></li>
-<li role="tab" ng-class="{active: controls.tab === 'group'}" ng-if="$ctrl.savedSearch.groups.length" title="{{ !$ctrl.groupExists ? ts('Group will be deleted.') : '' }}">
-  <a href ng-click="selectTab('group')" ng-disabled="!$ctrl.groupExists">
+<li role="presentation" ng-class="{active: controls.tab === 'group'}" ng-if="$ctrl.savedSearch.groups.length" title="{{ !$ctrl.groupExists ? ts('Group will be deleted.') : '' }}">
+  <a href role="tab" aria-selected="{{ controls.tab === 'group' }}" ng-click="selectTab('group')" ng-disabled="!$ctrl.groupExists">
     <i class="crm-i fa-users" role="img" aria-hidden="true"></i>
     {{:: ts('Smart Group') }} {{ $ctrl.savedSearch.groups[0].title }}
   </a>
@@ -14,8 +14,8 @@
     <i class="crm-i fa-{{ $ctrl.groupExists ? 'trash' : 'undo' }}" role="img" aria-hidden="true"></i>
   </button>
 </li>
-<li role="tab" ng-repeat="display in $ctrl.savedSearch.displays" ng-class="{active: controls.tab === ('display_' + $index)}" title="{{ display.trashed ? ts('Display will be deleted.') : '' }}">
-  <a href ng-click="selectTab('display_' + $index)" ng-disabled="display.trashed">
+<li role="presentation" ng-repeat="display in $ctrl.savedSearch.displays" ng-class="{active: controls.tab === ('display_' + $index)}" title="{{ display.trashed ? ts('Display will be deleted.') : '' }}">
+  <a href role="tab" aria-selected="{{ controls.tab === ('display_' + $index) }}" ng-click="selectTab('display_' + $index)" ng-disabled="display.trashed">
     <i class="crm-i {{ $ctrl.displayTypes[display.type].icon }}" role="img" aria-hidden="true"></i>
     {{ display.label || ts('Untitled') }}
   </a>
@@ -26,7 +26,7 @@
     <i class="crm-i fa-copy" role="img" aria-hidden="true"></i>
   </button>
 </li>
-<li role="tab">
+<li role="presentation">
   <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="crm-i fa-plus" role="img" aria-hidden="true"></i> {{:: ts('Add...') }} <span class="caret"></span>
   </button>


### PR DESCRIPTION
Overview
----------------------------------------

Core's Bootstrap tab strips put `role="tab"` on the `<li>` and leave the `<a>` inside it — the element that actually takes focus — with no role at all. The result is an accessibility tree where a link sits nested inside a non-focusable tab, and nothing carries which tab is current, because the `active` class is not exposed to assistive technology.

This moves `role="tab"` onto the anchor, marks the list item `role="presentation"`, and adds `aria-selected`. It matches [the ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) — *"The active tab element has the state aria-selected set to true and all other tab elements have it set to false"* — and it is what the Afform conditional dialog in core already does.

Before
----------------------------------------

Markup:

```html
<ul role="tablist" class="nav nav-tabs crm-tab-list">
  <li role="tab" class="crm-tab-button" ng-class="{active: …}">
    <a href ng-click="$ctrl.selectTab(tab.name)">
```

Chrome's accessibility tree for that strip:

```
tablist
 tab
  link "Details"
 tab
  link "Contributions"
 tab
  link "Notes"
```

After
----------------------------------------

```html
<ul role="tablist" class="nav nav-tabs crm-tab-list">
  <li role="presentation" class="crm-tab-button" ng-class="{active: …}">
    <a href role="tab" aria-selected="{{ tab.name === $ctrl.selectedTab }}" ng-click="$ctrl.selectTab(tab.name)">
```

Same strip, same page:

```
tablist
 presentation
  tab "Details"
 presentation
  tab "Contributions"
 presentation
  tab "Notes"
```

The focusable element is now the tab, and it reports its selected state.

Technical Details
----------------------------------------

Nine templates, all the Bootstrap/Angular strips in core:

| screen | template |
| --- | --- |
| Afform tab set (runtime) | `ext/afform/core/ang/af/afTabset.html` |
| Afform tab set (Form Builder canvas) | `ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.html` |
| Form Builder palette | `ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html` |
| Form Builder canvas heading | `ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html` |
| SearchKit admin side tabs | `ext/search_kit/ang/crmSearchAdmin/tabs.html` |
| SearchKit saved-search listing | `ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html` |
| Message templates listing | `ext/message_admin/ang/crmMsgadm/ListNav.html` |
| APIv4 explorer (code + result strips) | `ang/api4Explorer/Explorer.html` |
| OAuth client detail | `ext/oauth-client/ang/oauthProviderDetail.aff.html` |

- **Menu triggers inside these strips** — "Add Entity" and "Add Search" in the palette, SearchKit's "Add…" — become `role="presentation"` with no tab role on the control, since they open a dropdown rather than select a tab. SearchKit's `<li role="separator">` is untouched.
- **jQuery UI strips are deliberately excluded.** The widget itself does `this.tablist.find("> li:has(a[href])").attr({role: "tab", tabIndex: -1})` (`bower_components/jquery-ui/jquery-ui.js`), so it assigns the role to the item and would overwrite anything the markup says. That covers `crm-ui-tab-set` (Status Page, CiviMail), `TabHeader.tpl` and the report/contact strips; fixing those means changing or patching jQuery UI, not our templates.
- **No visual change.** Every selector involved is class-based — `.crm-tab-button`, `.nav-tabs > li.active`, `.af-gui-tabset`, `ul.nav-stacked li.active`. A grep across `*.css` and `*.js` finds no rule or script matching `[role=tab]`; the only `[role=…]` selector in core CSS is an unrelated `[role="button"]` rule in Riverlea.
- **Verified in a browser** on a standalone 6.20.alpha1 build, reading `role` / `aria-selected` off each strip and comparing Chrome's accessibility tree before and after:
  - Afform tab set, runtime: tree as quoted above; clicking a tab switches the panel and `aria-selected` moves `false / true / false`
  - Form Builder palette, canvas heading and canvas tab set: items `presentation`, anchors `tab`, `aria-selected` `true` on the current one; the palette's "Add Entity" trigger correctly has no tab role
  - SearchKit admin: `tablist > presentation > tab "Search For" …`, appearance unchanged
  - SearchKit saved-search listing, message templates, APIv4 explorer (both strips): all `presentation / tab / aria-selected`

Comments
----------------------------------------

Two things left out on purpose, both more than a markup fix:

- `aria-controls` and `aria-labelledby` pairing between each tab and its panel, and a roving `tabindex`, which the ARIA pattern also asks for. The message-templates screen gets the pairing in a separate PR because its panel was being restructured anyway.
- The jQuery UI strips above.

