### PR TITLE
Use native structuredClone() in ckeditor4, civi_case and chart_kit

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -34,6 +34,7 @@
     "URLSearchParams",
     "TextEncoder",
     "crypto",
+    "structuredClone",
     "CSSStyleSheet",
     "Event",
     "HTMLElement",

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -171,7 +171,7 @@
       const actionInfo = entityInfo.actions.find((a) => a && a.name === action);
       // Avoid crash before metadata has been fetched
       if (actionInfo) {
-        const fieldInfo = _.cloneDeep(actionInfo.fields);
+        const fieldInfo = structuredClone(actionInfo.fields);
         if (addPseudoconstant) {
           addPseudoconstants(fieldInfo);
         }
@@ -187,11 +187,11 @@
       // Add entities specified by the join param
       Object.values(getExplicitJoins()).forEach(join => {
         let wildCard = addWildcard ? [{id: join.alias + '.*', text: join.alias + '.*', 'description': 'All core ' + join.entity + ' fields'}] : [],
-          joinFields = _.cloneDeep(entityFields(join.entity));
+          joinFields = structuredClone(entityFields(join.entity));
         if (joinFields) {
           // Add fields from bridge entity
           if (join.bridge) {
-            const bridgeFields = _.cloneDeep(entityFields(join.bridge)),
+            const bridgeFields = structuredClone(entityFields(join.bridge)),
               bridgeEntity = getEntity(join.bridge),
               joinFieldNames = joinFields.map((f) => f.name),
               // Check if this is a symmetric bridge e.g. RelationshipCache joins Contact to Contact
@@ -222,7 +222,7 @@
       // Add implicit joins based on schema links
       Object.values(entityFields($scope.entity, $scope.action)).forEach((field) => {
         if (field?.fk_entity) {
-          let linkFields = _.cloneDeep(entityFields(field.fk_entity)) ?? [],
+          let linkFields = structuredClone(entityFields(field.fk_entity)) ?? [],
             wildCard = addWildcard ? [{id: field.name + '.*', text: field.name + '.*', 'description': 'All core ' + field.fk_entity + ' fields'}] : [];
           if (addPseudoconstant) {
             addPseudoconstants(linkFields);
@@ -258,7 +258,7 @@
         const fkNameField = field?.fk_entity && getField('name', field.fk_entity, $scope.action);
 
         if (fkNameField && !field.name.includes(':')) {
-          const newField = _.cloneDeep(fkNameField);
+          const newField = structuredClone(fkNameField);
           newField.name = field.name + '.' + newField.name;
           // Insert new field after the current one
           fieldList.splice(pos + 1, 0, newField);
@@ -300,7 +300,7 @@
           see[idx] = '<a target="' + (ref[0] === '#' ? '_self' : '_blank') + '" href="' + ref + '">' + see[idx] + '</a>';
         });
       }
-      const formatted = _.cloneDeep(rawContent);
+      const formatted = structuredClone(rawContent);
       if (formatted.description) {
         formatted.description = marked(formatted.description);
       }
@@ -468,7 +468,7 @@
         if (params[key]) {
           const newParam = {};
           Object.values(params[key]).forEach((item) => {
-            let val = _.cloneDeep(item[1]);
+            let val = structuredClone(item[1]);
             // Remove blank items from "chain" array
             if (Array.isArray(val)) {
               item[1].slice().reverse().some((v) => {
@@ -567,7 +567,7 @@
 
         Object.entries(actionInfo.params || {}).forEach(([name, param]) => {
           let format;
-          let defaultVal = _.cloneDeep(param.default);
+          let defaultVal = structuredClone(param.default);
 
           if (param.type) {
             switch (param.type[0]) {
@@ -685,7 +685,7 @@
                 } else if (typeof objectParams[name] === 'undefined') {
                   $scope.params[name].push(field);
                 } else {
-                  const defaultOp = _.cloneDeep(objectParams[name]);
+                  const defaultOp = structuredClone(objectParams[name]);
 
                   if (name === 'chain') {
                     const num = $scope.params.chain.length;
@@ -962,7 +962,7 @@ apiCalls.${results} = [${jsCall}];
       const info = getEntity(entity),
         arrayParams = ['groupBy', 'records'],
         newLine = "\n" + _.repeat(' ', indent),
-        args = _.cloneDeep(info.class_args || []);
+        args = structuredClone(info.class_args || []);
       let code = '\\' + info.class + '::' + action + '(';
       // Always shows implicit true permissions check for PHP
       args.push(params.checkPermissions !== false);
@@ -1683,7 +1683,7 @@ apiCalls.${results} = [${jsCall}];
     const [baseFieldName, suffix] = fieldName.split(':');
     const fieldNames = baseFieldName.split('.');
 
-    const field = _.cloneDeep(get(entity, fieldNames));
+    const field = structuredClone(get(entity, fieldNames));
 
     if (field && suffix) {
       field.pseudoconstant = suffix;

--- a/ext/chart_kit/js/components/civi-search-display.js
+++ b/ext/chart_kit/js/components/civi-search-display.js
@@ -114,7 +114,7 @@
     // TODO: move to connectedCallback and use super
     initializeDisplay() {
       this.limit = this.settings.limit;
-      this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : [];
+      this.sort = this.settings.sort ? structuredClone(this.settings.sort) : [];
       this.uniqueId = Math.floor(Math.random() * 10e10);
       this.placeholders = [];
       const placeholderCount = 'placeholder' in this.settings ? this.settings.placeholder : 5;

--- a/ext/civi_case/ang/crmCaseType.js
+++ b/ext/civi_case/ang/crmCaseType.js
@@ -350,7 +350,7 @@
       var isNewCaseType = !apiCalls.caseType;
 
       if (isNewCaseType) {
-        $scope.caseType = _.cloneDeep(newCaseTypeTemplate);
+        $scope.caseType = structuredClone(newCaseTypeTemplate);
       } else {
         $scope.caseType = apiCalls.caseType;
       }

--- a/ext/ckeditor4/js/admin.ckeditor-configurator.js
+++ b/ext/ckeditor4/js/admin.ckeditor-configurator.js
@@ -55,7 +55,7 @@
   function getOptionList() {
     var list = [];
     _.forEach(options, function(option) {
-      var opt = _.cloneDeep(option);
+      var opt = structuredClone(option);
       if ($('[name="config_' + opt.id + '"]').length) {
         opt.disabled = true;
       }

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -110,7 +110,7 @@
   function getField(name) {
     var field = {};
     if (name && getFieldData[name]) {
-      field = _.cloneDeep(getFieldData[name]);
+      field = structuredClone(getFieldData[name]);
     } else if (name) {
       var ent = entity,
         act = action,
@@ -124,7 +124,7 @@
         prefix += (prefix.length ? '.' : '') + piece;
       });
       if (getFieldsCache[ent+act].values[name]) {
-        field = _.cloneDeep(getFieldsCache[ent+act].values[name]);
+        field = structuredClone(getFieldsCache[ent+act].values[name]);
       }
     }
     addJoinInfo(field, name);
@@ -293,7 +293,7 @@
           return ret;
         }, {})
       };
-      getFieldsCache[entity+action] = {values: _.cloneDeep(getFieldData)};
+      getFieldsCache[entity+action] = {values: structuredClone(getFieldData)};
       showFields(['api_action']);
       renderJoinSelector();
       return;
@@ -859,7 +859,7 @@
             };
           }
         });
-      })(_.cloneDeep(getFieldData), joinable, '', 1, [entity]);
+      })(structuredClone(getFieldData), joinable, '', 1, [entity]);
       if (!_.isEmpty(joinable)) {
         // Send joinTpl as a param so it can recursively call itself to render children
         $('#api-join').show().children('div').html(joinTpl({joins: joinable, tpl: joinTpl}));


### PR DESCRIPTION
Overview
----------------------------------------

Replaces the last three `_.cloneDeep()` calls outside `search_kit` with the browser-native `structuredClone()`, as part of the ongoing removal of lodash from core JavaScript.

Stacked on #36764 - please review that one first. This branch adds only the three-line commit on top; the `.jshintrc` change belongs to #36764.

Before
----------------------------------------

Three unrelated extensions each deep-clone one plain value through lodash:

```js
var opt = _.cloneDeep(option);                                      // ckeditor4
$scope.caseType = _.cloneDeep(newCaseTypeTemplate);                 // civi_case
this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : []; // chart_kit
```

After
----------------------------------------

```js
var opt = structuredClone(option);
$scope.caseType = structuredClone(newCaseTypeTemplate);
this.sort = this.settings.sort ? structuredClone(this.settings.sort) : [];
```

No user-visible change.

Technical Details
----------------------------------------

`structuredClone()` is not a blanket substitute for `_.cloneDeep()`: lodash passes functions held as object properties through by reference, whereas `structuredClone()` throws `DataCloneError` if a function appears anywhere in the graph. It is only safe where the cloned value is known to be plain data.

All three qualify:

- `ext/ckeditor4/js/admin.ckeditor-configurator.js` — an entry from `ck-options.json`, fetched with `$.getJSON`.
- `ext/civi_case/ang/crmCaseType.js` — `newCaseTypeTemplate`, the object literal declared at the top of the same file (strings and nested arrays only).
- `ext/chart_kit/js/components/civi-search-display.js` — a search display's `sort` setting, an array of `[field, direction]` string pairs stored as JSON.

Comments
----------------------------------------

Tested manually against a Standalone build, with no console errors.

- **CKEditor config** (`civicrm/admin/ckeditor`) — the custom config option list renders with names, types and descriptions, and options already in use are still marked accordingly.
- **New Case Type** (`civicrm/a/#/caseType/new`) — the form is built entirely from the cloned template: the Case Coordinator role with its creator and manager flags, the Standard Timeline set, and all five activity types with Open Case limited to one instance.
- **chart_kit** — enabled the extension, built a bar chart of Contacts grouped by Contact Type, and it rendered correctly through `initializeDisplay()`. Also checked the `sort` path specifically: setting `sort` to `[["contact_type:label","DESC"],["COUNT_id","ASC"]]` on the component and re-initialising gives a value equal to the setting, held in a different array with freshly cloned inner rows — the same deep copy lodash produced. (An ordinary chart render doesn't surface this, because `alwaysSortByDimAscending()` replaces `this.sort` immediately afterwards.)
