### PR TITLE
Remove dead $_fields billing loops from AbstractEditPayment and Participant

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -44,8 +44,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    */
   public $_bltID;
 
-  public $_fields = [];
-
   /**
    * Current payment processor including a copy of the object in 'object' key.
    *
@@ -542,10 +540,6 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
 
     $fields['email-Primary'] = 1;
     $this->_params['email-5'] = $this->_params['email-Primary'] = $email;
-    // now set the values for the billing location.
-    foreach (array_keys($this->_fields) as $name) {
-      $fields[$name] = 1;
-    }
     $billingLocationID = CRM_Core_BAO_LocationType::getBilling();
     $fields["address_name-{$billingLocationID}"] = 1;
 

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -477,7 +477,6 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       $this->_mode = $creditCardMode;
     }
 
-    $this->_fields = [];
     $this->set('cid', $this->_contactId);
     parent::preProcess();
     $this->submit($params);

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -842,11 +842,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       $fields['email-Primary'] = 1;
       $params['email-Primary'] = $params["email-{$this->_bltID}"] = $this->getContactValue('email_primary.email');
 
-      // now set the values for the billing location.
-      foreach ($this->_fields as $name => $dontCare) {
-        $fields[$name] = 1;
-      }
-
       // also add location name to the array
       $params["address_name-{$this->_bltID}"]
         = ($params['billing_first_name'] ?? '') . ' ' .


### PR DESCRIPTION


Overview
-----------------------------------
Remove dead $_fields billing loops from AbstractEditPayment and Participant

Before
----------------------------------------
$_fields checked on these 2 forms but never set

After
----------------------------------------
poof

Technical Details
----------------------------------------
I asked Claude to double check my conclusion that these are not set - these are claude's notes


$this->_fields on CRM_Contribute_Form_AbstractEditPayment was declared and, in one spot, reset to [] but never assigned any real content anywhere in its class hierarchy (AbstractEditPayment, AdditionalPayment, Contribution, Member/Form, Event/Form/Participant). That left two foreach loops (in AbstractEditPayment::processBillingAddress() and a near-duplicate in Participant's own billing block) permanently iterating an empty array, contributing nothing to the $fields array they built.

Checks done before removing:
- Confirmed no assignment of the form `$this->_fields[...] = ...` exists anywhere in the four classes that extend AbstractEditPayment, via `git log -S'->_fields['` over their history as well as a plain grep of the current tree.
- Distinguished this from same-named but unrelated `_fields` properties on other classes (e.g. CRM_Contact_BAO_Query, UFGroup batch/profile forms), which are populated and legitimately in use.
- Grepped templates and the rest of the codebase for external reads of `_fields` on these specific form classes; found none, so the public property itself is also safe to drop.


Comments
----------------------------------------
