### PR TITLE
Use structuredClone() and CRM.utils.cloneDeep() in search_kit instead of lodash

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -222,7 +222,7 @@
           }
         }
         const defaultLabel = labels.join(' - ');
-        result = _.assign(_.cloneDeep(join), {
+        result = _.assign(structuredClone(join), {
           label: (savedSearch && savedSearch.form_values && savedSearch.form_values.join && savedSearch.form_values.join[alias]) || defaultLabel,
           defaultLabel: defaultLabel,
           alias: alias,

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -228,7 +228,7 @@
       this.savedSearch.form_values.join = this.savedSearch.form_values.join || {};
       this.savedSearch.groups = this.savedSearch.groups || [];
       this.savedSearch.tag_id = this.savedSearch.tag_id || [];
-      this.originalSavedSearch = _.cloneDeep(this.savedSearch);
+      this.originalSavedSearch = structuredClone(this.savedSearch);
       this.groupExists = !!this.savedSearch.groups.length;
 
       this.savedSearch.displays.forEach(function(display) {
@@ -422,12 +422,12 @@
       ctrl.originalSavedSearch.displays.forEach(function(original) {
         const key = original.id ? ('id_' + original.id) : ('new_' + (newCount++));
         targets[key] = targets[key] || {};
-        targets[key].original = _.cloneDeep(original);
+        targets[key].original = structuredClone(original);
       });
       ctrl.savedSearch.displays.forEach(function(updated) {
         const key = updated.id ? ('id_' + updated.id) : ('new_' + (newCount++));
         targets[key] = targets[key] || {};
-        targets[key].updated = _.cloneDeep(updated);
+        targets[key].updated = structuredClone(updated);
       });
 
       fireHooks('findCriticalChanges', Object.values(targets), data);
@@ -444,7 +444,7 @@
         return;
       }
       $scope.status = 'saving';
-      const params = _.cloneDeep(ctrl.savedSearch),
+      const params = structuredClone(ctrl.savedSearch),
         apiCalls = {},
         chain = {};
 
@@ -500,7 +500,7 @@
           ctrl.savedSearch.groups[0].id = results.saved.groups[0].id;
         }
         ctrl.savedSearch.displays = results.saved.displays || [];
-        ctrl.originalSavedSearch = _.cloneDeep(ctrl.savedSearch);
+        ctrl.originalSavedSearch = structuredClone(ctrl.savedSearch);
         // Wait until after onChangeAnything to update status
         $timeout(function() {
           $scope.status = newStatus;
@@ -871,7 +871,7 @@
 
       // Links to main entity
       const mainEntity = searchMeta.getEntity(ctrl.savedSearch.api_entity);
-      const links = _.cloneDeep(mainEntity.links || []);
+      const links = structuredClone(mainEntity.links || []);
       links.forEach(link => {
         link.join = '';
         addTitle(link, mainEntity.title);
@@ -881,12 +881,12 @@
         const join = searchMeta.getJoin(ctrl.savedSearch, joinClause[0]);
         const joinEntity = searchMeta.getEntity(join.entity);
         const bridgeEntity = typeof joinClause[2] === 'string' ? searchMeta.getEntity(joinClause[2]) : null;
-        _.cloneDeep(joinEntity.links || []).forEach(link => {
+        structuredClone(joinEntity.links || []).forEach(link => {
           link.join = join.alias;
           addTitle(link, join.label);
           links.push(link);
         });
-        _.cloneDeep(bridgeEntity?.links || []).forEach(link => {
+        structuredClone(bridgeEntity?.links || []).forEach(link => {
           link.join = join.alias;
           addTitle(link, join.label + (bridgeEntity.bridge_title ? ' ' + bridgeEntity.bridge_title : ''));
           links.push(link);
@@ -902,7 +902,7 @@
             if (!ctrl.mustAggregate(idFieldName, ctrl.savedSearch)) {
               const joinEntity = searchMeta.getEntity(idField.fk_entity);
               const label = (idField.join ? idField.join.label + ': ' : '') + (idField.input_attrs && idField.input_attrs.label || idField.label);
-              _.cloneDeep(joinEntity?.links || []).forEach(link => {
+              structuredClone(joinEntity?.links || []).forEach(link => {
                 link.join = idFieldName;
                 addTitle(link, label);
                 links.push(link);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -115,7 +115,7 @@
       };
 
       this.addCol = function(type) {
-        const col = _.cloneDeep(this.colTypes[type].defaults);
+        const col = structuredClone(this.colTypes[type].defaults);
         col.type = type;
         if (this.display.type === 'table' && !('alignment' in col)) {
           col.alignment = 'text-right';

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminJoin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminJoin.component.js
@@ -90,9 +90,9 @@
           const entity = searchMeta.getEntity(join.entity);
           const params = [value, $scope.controls.joinType || 'LEFT'];
           // Immutable conditions cannot be changed in the SK UI
-          params.push(... _.cloneDeep(join.conditions || []));
+          params.push(... structuredClone(join.conditions || []));
           // Default conditions are user-editable in the SK UI
-          params.push(... _.cloneDeep(join.defaults || []));
+          params.push(... structuredClone(join.defaults || []));
           this.apiParams.join.push(params);
           if (entity.search_fields && $scope.controls.joinType !== 'EXCLUDE') {
             // Add columns for newly-joined entity

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -64,7 +64,7 @@
           // This function has to return a reference to avoid angering angular
           // But we also can't alter the global `fn` variables returned by `parseExpr()`
           // So make a copy of the object and stash it locally to return by ref
-          let parsed = _.cloneDeep(searchMeta.parseExpr(expr, ctrl.savedSearch));
+          let parsed = structuredClone(searchMeta.parseExpr(expr, ctrl.savedSearch));
           // Pass-thru data_type of expression if fn doesn't have a data_type
           parsed.fn.data_type = parsed.fn.data_type || parsed.data_type;
           return (functionCache[expr] = parsed.fn);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
@@ -19,7 +19,7 @@
         return searchMeta.getField(fieldName, ctrl.crmSearchAdmin.savedSearch);
       };
 
-      this.styles = _.transform(_.cloneDeep(CRM.crmSearchAdmin.styles), function(styles, style) {
+      this.styles = _.transform(structuredClone(CRM.crmSearchAdmin.styles), function(styles, style) {
         if (style.key !== 'default' && style.key !== 'secondary') {
           styles['bg-' + style.key] = style.value;
         }

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.component.js
@@ -12,10 +12,10 @@
         ctrl = this;
 
       function getDefaultSettings() {
-        return _.cloneDeep({
+        return {
           show_count: false,
           expose_limit: false
-        });
+        };
       }
 
       this.$onInit = function() {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/crmSearchDisplayEntity.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/crmSearchDisplayEntity.component.js
@@ -14,7 +14,7 @@
     controller: function($scope, $element, searchDisplayBaseTrait) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in a copy of searchDisplayBaseTrait
-        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait));
+        ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait));
 
       this.$onInit = function() {
         // Adding this stuff for the sake of preview, but pollutes the display settings

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -26,7 +26,7 @@
 
       this.$onInit = function () {
         if (!ctrl.display.settings) {
-          ctrl.display.settings = _.extend({}, _.cloneDeep(CRM.crmSearchAdmin.defaultDisplay.settings), {columns: null, pager: {}});
+          ctrl.display.settings = _.extend({}, structuredClone(CRM.crmSearchAdmin.defaultDisplay.settings), {columns: null, pager: {}});
           ctrl.display.settings.sort = ctrl.parent.getDefaultSort();
         }
         // Displays created prior to 5.43 may not have this property

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -14,11 +14,11 @@
     controller: function($scope, $element, searchMeta, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
       // Mix in copies of traits to this controller
-      const ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplaySortableTrait));
+      const ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplayTasksTrait), CRM.utils.cloneDeep(searchDisplaySortableTrait));
 
       function buildSettings() {
         ctrl.apiEntity = ctrl.search.api_entity;
-        ctrl.settings = _.cloneDeep(CRM.crmSearchAdmin.defaultDisplay.settings);
+        ctrl.settings = structuredClone(CRM.crmSearchAdmin.defaultDisplay.settings);
         ctrl.settings.button = ts('Search');
         ctrl.settings.columns = ctrl.search.api_params.select
           .map(fieldExpr => searchMeta.fieldToColumn(fieldExpr, {label: true, sortable: true}, ctrl.search));
@@ -31,7 +31,7 @@
           alignment: 'text-right',
           links: [],
         });
-        ctrl.columns = _.cloneDeep(ctrl.settings.columns);
+        ctrl.columns = structuredClone(ctrl.settings.columns);
         ctrl.columns.forEach((col) => {
           col.enabled = true;
           col.fetched = true;

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -11,7 +11,7 @@
     controller: function($scope, $element, $q, crmApi4, crmStatus, searchMeta, searchDisplayBaseTrait, searchDisplaySortableTrait, searchDisplayEditableTrait) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in traits to this controller
-        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplaySortableTrait), _.cloneDeep(searchDisplayEditableTrait));
+        ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplaySortableTrait), CRM.utils.cloneDeep(searchDisplayEditableTrait));
       let afformLoad;
 
       $scope.crmUrl = CRM.url;

--- a/ext/search_kit/ang/crmSearchAdmin/searchSegmentListing/crmSearchAdminSegmentListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchSegmentListing/crmSearchAdminSegmentListing.component.js
@@ -11,7 +11,7 @@
     controller: function($scope, $element, crmApi4, searchMeta, searchDisplayBaseTrait, searchDisplaySortableTrait) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in traits to this controller
-        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplaySortableTrait));
+        ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplaySortableTrait));
 
       this.apiEntity = 'SearchSegment';
       this.search = {

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -22,7 +22,7 @@
         const ctrl = this;
         this.$element = $element;
         this.limit = this.settings.limit;
-        this.sort = Array.isArray(this.settings.sort) ? _.cloneDeep(this.settings.sort) : [];
+        this.sort = Array.isArray(this.settings.sort) ? structuredClone(this.settings.sort) : [];
         // Used to make dom ids unique, and as a seed for ORDER BY RAND() to stabilize random results
         this.uniqueId = Math.floor(Math.random() * 10e10);
         this.placeholders = [];
@@ -57,7 +57,7 @@
         }
         else {
           // Break reference so original settings are preserved
-          this.columns = _.cloneDeep(this.settings.columns);
+          this.columns = structuredClone(this.settings.columns);
           this.columns.forEach(setColumnDefaults);
         }
 

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
@@ -22,7 +22,7 @@
     controller: function($scope, $element, $location, $interval, $q, crmApi4, searchDisplayBaseTrait, searchDisplayEditableTrait) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
       // Mix in required traits
-      const ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayEditableTrait));
+      const ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplayEditableTrait));
 
       let autoSaveTimer;
       let errorNotification;
@@ -41,7 +41,7 @@
         // When previewing on the search admin screen, the display will be view-only
         this.isPreviewMode = typeof this.search !== 'string';
         this.userJobId = this.isPreviewMode ? null : $location.search().batch;
-        this.columns = _.cloneDeep(this.settings.columns);
+        this.columns = structuredClone(this.settings.columns);
         // Run search if a userJobId is given. Otherwise the "Start New Batch" button will be shown.
         if (this.userJobId) {
           this.runSearch();

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.component.js
@@ -18,7 +18,7 @@
     controller: function($scope, $element, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplayEditableTrait) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in required traits
-        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplayEditableTrait));
+        ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplayTasksTrait), CRM.utils.cloneDeep(searchDisplayEditableTrait));
 
       this.$onInit = function() {
         this.initializeDisplay($scope, $element);

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.component.js
@@ -18,7 +18,7 @@
     controller: function($scope, $element, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplayEditableTrait) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in required traits
-        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplayEditableTrait));
+        ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplayTasksTrait), CRM.utils.cloneDeep(searchDisplayEditableTrait));
 
       this.$onInit = function() {
         this.initializeDisplay($scope, $element);

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -17,7 +17,7 @@
     controller: function($scope, $element, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplaySortableTrait, searchDisplayEditableTrait, crmApi4, crmStatus) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         // Mix in copies of traits to this controller
-        ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplaySortableTrait), _.cloneDeep(searchDisplayEditableTrait));
+        ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplayTasksTrait), CRM.utils.cloneDeep(searchDisplaySortableTrait), CRM.utils.cloneDeep(searchDisplayEditableTrait));
 
       this.$onInit = function() {
         let tallyParams;
@@ -28,7 +28,7 @@
         if (ctrl.settings.tally) {
           ctrl.onPreRun.push(function (apiCalls) {
             ctrl.tally = null;
-            tallyParams = _.cloneDeep(apiCalls.run[2]);
+            tallyParams = structuredClone(apiCalls.run[2]);
           });
 
           ctrl.onPostRun.push(function (apiResults, status) {

--- a/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTree.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTree.component.js
@@ -18,7 +18,7 @@
     controller: function($scope, $element, searchDisplayBaseTrait, searchDisplayTasksTrait, searchDisplayEditableTrait) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
       // Mix in required traits
-      const ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplayEditableTrait));
+      const ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplayTasksTrait), CRM.utils.cloneDeep(searchDisplayEditableTrait));
 
       this.tree = [];
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -52,7 +52,7 @@
         if (ctrl.last > ctrl.ids.length) {
           ctrl.last = ctrl.ids.length;
         }
-        const params = _.cloneDeep(ctrl.params);
+        const params = structuredClone(ctrl.params);
         if (ctrl.action === 'save' || (ctrl.action === 'create' && ctrl.idField)) {
           actionName = 'save';
           let originalRecords = params.records || [{}];
@@ -63,7 +63,7 @@
           }
           // For the save action, take each record from params and copy it with each supplied id
           params.records = _.transform(ctrl.ids.slice(ctrl.first, ctrl.last), function(records, id) {
-            _.each(_.cloneDeep(originalRecords), function(record) {
+            _.each(structuredClone(originalRecords), function(record) {
               record[ctrl.idField || 'id'] = id;
               records.push(record);
             });

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRelationship.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRelationship.js
@@ -47,7 +47,7 @@
     };
 
     this.submit = function() {
-      const apiValues = _.cloneDeep(values);
+      const apiValues = structuredClone(values);
       const relationshipType = values.relationship_type.split('_')[0];
       const a = values.relationship_type.split('_')[1];
       const b = values.relationship_type.split('_')[2];

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -52,7 +52,7 @@
           taskManager: mngr,
           entityInfo: mngr.entityInfo,
           isLink: isLink,
-          task: _.cloneDeep(task),
+          task: structuredClone(task),
         };
         // If task uses a crmPopup form
         if (task.crmPopup) {


### PR DESCRIPTION
Overview
----------------------------------------

Removes the last `_.cloneDeep()` calls from core JavaScript, in `search_kit`. With #36703 (which this is stacked on) merged, no core JS file calls lodash's `cloneDeep` any more.

Please review #36703 first — it adds the `CRM.utils.cloneDeep()` helper this PR relies on, and appears as the first commit here.

Before
----------------------------------------

`search_kit` held 51 `_.cloneDeep()` calls, of two quite different kinds. Most clone plain data:

```js
this.columns = _.cloneDeep(this.settings.columns);
```

but 24 of them mix display traits into a component, cloning service objects made entirely of methods:

```js
ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplaySortableTrait), _.cloneDeep(searchDisplayEditableTrait));
```

After
----------------------------------------

The plain-data clones use the native function:

```js
this.columns = structuredClone(this.settings.columns);
```

and the trait mixins use the helper, which handles values `structuredClone()` refuses:

```js
ctrl = angular.extend(this, CRM.utils.cloneDeep(searchDisplayBaseTrait), CRM.utils.cloneDeep(searchDisplayTasksTrait), CRM.utils.cloneDeep(searchDisplaySortableTrait), CRM.utils.cloneDeep(searchDisplayEditableTrait));
```

No user-visible change.

Technical Details
----------------------------------------

`structuredClone()` throws `DataCloneError` if a function appears anywhere in the value, whereas lodash passed functions through by reference. The 51 calls split accordingly:

- **24 → `CRM.utils.cloneDeep()`.** These are the `angular.extend(this, cloneDeep(trait), …)` mixins across the table, list, grid, tree, batch and entity displays plus the three admin
listings. The traits are objects of methods, so native cloning is not an optilper exists for.
- **26 → `structuredClone()`.** Saved search and display records, entity/field/link metadata from `CRM.crmSearchAdmin` (injected by PHP), join conditions and defaults, API params, and
task definitions returned by `SearchDisplay.getSearchTasks`.
- **1 dropped.** `searchAdminPagerConfig.getDefaultSettings()` cloned an object literal it had just constructed, which was a no-op; it now returns the literal.

Two of these were worth checking rather than assuming. `colTypes[type].defaults` turned out to be plain literals (strings, empty arrays, nested plain objects). And `searchMeta.parseExpr()` returns an object with an `fn` property — that is a function *descriptor* from the server's function metadata, not a callable; I confirmed in the browser that
its output holds no function properties six levels deep and that `structuredC

Counting note: `search_kit` has 51 `cloneDeep` *calls* spread over 36 lines, t several times each.

Comments
----------------------------------------

Tested manually against a Standalone build, with no console errors introduced.

Every one of the 24 trait-mixin call sites was exercised by rendering the component that uses it:

- SearchKit's saved-search listing and search-segment listing.
- The admin results-table preview.
- Table, List, Grid, Tree, DB Entity and Data Entry displays, each previewed with real data.
- The saved Table display viewed standalone.

And the plain-data sites:

- Adding an Email join, which pulls in the join's immutable conditions and ed
- Adding a Links column, which clones the column-type defaults and then the entity's links — the link titles are written onto the clones, so a shared reference here would corrupt the shared metadata; the generated View/Update/Delete Contact links came out correct.
- The Row Style menu, populated from the cloned style metadata.
- Saving, which clones the saved search for the API call and for the "critical changes" comparison.
- Running a task from a display, which clones the task definition before evaluating its popup expressions.
