### PR TITLE
CiviMail - Fix entityRef custom fields in mailings

### DIFF
--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -50,7 +50,13 @@
         };
 
         this.getFormName = function() {
-          return ctrl.afFormCtrl ? ctrl.afFormCtrl.getFormMeta().name : $scope.meta.name;
+          if (ctrl.afFormCtrl) {
+            return ctrl.afFormCtrl.getFormMeta().name;
+          }
+          if ($scope.meta) {
+            return $scope.meta.name;
+          }
+          return $element.closest('form').attr('name');
         };
 
         this.getFieldMeta = () => {


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/36282 - fixes EntityRef fields in mailings.

Technical Details
----------------------------------------
Mailing custom fields reuse afform components, without an afform. This means there is no formName. Previously this would crash when using an EntityRef autocomplete; this fixes the issue.