### PR TITLE
Use structuredClone() instead of JSON parse/stringify in SearchKit and Afform

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -426,7 +426,7 @@
         ctrl.fieldDefn = angular.merge({}, ctrl.getDefn(), ctrl.node.defn);
         // Undo deep merge of options array.
         if (ctrl.node.defn && ctrl.node.defn.options) {
-          ctrl.fieldDefn.options = JSON.parse(JSON.stringify(ctrl.node.defn.options));
+          ctrl.fieldDefn.options = structuredClone(ctrl.node.defn.options);
         }
       }
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -372,7 +372,7 @@
       // Convert to EntitySet: move current entity/params into the first set
       else {
         const entity = this.savedSearch.api_entity;
-        const params = JSON.parse(JSON.stringify(this.savedSearch.api_params));
+        const params = structuredClone(this.savedSearch.api_params);
         delete params.version;
         delete params.having;
         newEntity = 'EntitySet';

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -25,8 +25,8 @@
         this.display.editValues = this.display.editValues || {};
         // Not applicable to create mode
         if (this.row) {
-          initialValue = JSON.parse(JSON.stringify(this.row.data[valuePath]));
-          this.display.editValues[this.colKey] = JSON.parse(JSON.stringify(this.row.data[valuePath]));
+          initialValue = structuredClone(this.row.data[valuePath]);
+          this.display.editValues[this.colKey] = structuredClone(this.row.data[valuePath]);
         }
 
         this.field = {


### PR DESCRIPTION
Overview
----------------------------------------
Part of an ongoing refactor toward preferring `structuredClone()` for deep-cloning JavaScript objects.

Before
----------------------------------------
`JSON.parse(JSON.stringify(...))` was used to clone plain objects and arrays in SearchKit and Afform.

After
----------------------------------------
Replaced with native `structuredClone(...)`.
