### PR TITLE
Replace lodash includes/contains with native Array/String includes()

### DIFF
--- a/ang/crmEntityTags.js
+++ b/ang/crmEntityTags.js
@@ -64,7 +64,7 @@
       };
 
       this.hasTag = function(tag) {
-        return _.includes(ctrl.tagIds, tag.id);
+        return ctrl.tagIds.includes(tag.id);
       };
 
       this.getStyle = function(id) {

--- a/ang/crmUtil.js
+++ b/ang/crmUtil.js
@@ -318,7 +318,7 @@
 
       function checkResult(result, success) {
         _.pull(executing, func);
-        if (_.includes(pending, func)) {
+        if (pending.includes(func)) {
           runNext();
         } else if (success) {
           deferred.resolve(result);
@@ -337,9 +337,9 @@
         });
       }
 
-      if (!_.includes(executing, func)) {
+      if (!executing.includes(func)) {
         runNext();
-      } else if (!_.includes(pending, func)) {
+      } else if (!pending.includes(func)) {
         pending.push(func);
       }
       return deferred.promise;

--- a/ang/exportui/exportui.js
+++ b/ang/exportui/exportui.js
@@ -54,7 +54,7 @@
         $scope.data.columns = [];
         var mapContactTypes = [];
         _.each(map, function (col) {
-          if (_.contains(contactTypes, col.contact_type)) {
+          if (contactTypes.includes(col.contact_type)) {
             mapContactTypes.push(col.contact_type);
           }
           if (col.relationship_type_id && col.relationship_direction) {
@@ -78,7 +78,7 @@
             return;
           }
           var fields = _.filter(cat.children, function (field) {
-            return !field.contact_type || !contactType || _.contains(field.contact_type, contactType);
+            return !field.contact_type || !contactType || field.contact_type.includes(contactType);
           });
           if (fields.length) {
             result.push({
@@ -158,7 +158,7 @@
           new_name: CRM.vars.exportUi.mapping_id ? CRM.vars.exportUi.mapping_names[CRM.vars.exportUi.mapping_id] : '',
           description: CRM.vars.exportUi.mapping_description,
           nameIsUnique: function () {
-            return !_.contains(mappingNames, this.new_name.toLowerCase()) || (this.overwrite === '1' && this.new_name.toLowerCase() === this.mapping_names[this.mapping_id].toLowerCase());
+            return !mappingNames.includes(this.new_name.toLowerCase()) || (this.overwrite === '1' && this.new_name.toLowerCase() === this.mapping_names[this.mapping_id].toLowerCase());
           },
           saveMapping: function () {
             this.saving = true;

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -14,7 +14,7 @@
           if (_.isPlainObject(item)) {
             evaluate(item['#children']);
             _.each(item, function(prop, key) {
-              if (typeof prop === 'string' && !_.includes(doNotEval, key)) {
+              if (typeof prop === 'string' && !doNotEval.includes(key)) {
                 if (looksLikeJs(prop)) {
                   try {
                     item[key] = $parse(prop)({ts: CRM.ts('afform')});

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -461,7 +461,7 @@
         } else {
           const searchDisplay = ctrl.getSearchDisplay(),
             fieldName = fieldKey.substr(fieldKey.indexOf('.') + 1),
-            prefix = _.includes(fieldKey, '.') ? fieldKey.split('.')[0] : null;
+            prefix = fieldKey.includes('.') ? fieldKey.split('.')[0] : null;
           if (prefix) {
             _.each(searchDisplay['saved_search_id.api_params'].join, function(join) {
               const joinInfo = join[0].split(' AS ');

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -88,8 +88,8 @@
             // Multiselects cannot use range search
             !ctrl.getDefn().input_attrs.multiple &&
             // DataType & inputType must make sense for a range
-            _.includes(['Date', 'Timestamp', 'Integer', 'Float', 'Money'], ctrl.getDefn().data_type) &&
-            _.includes(['Date', 'Number', 'Select'], $scope.getProp('input_type'))
+            ['Date', 'Timestamp', 'Integer', 'Float', 'Money'].includes(ctrl.getDefn().data_type) &&
+            ['Date', 'Number', 'Select'].includes($scope.getProp('input_type'))
         ));
       };
 
@@ -240,7 +240,7 @@
           }
           return entityRefOptions;
         }
-        if (_.includes(['Date', 'Timestamp'], $scope.getProp('data_type'))) {
+        if (['Date', 'Timestamp'].includes($scope.getProp('data_type'))) {
           ctrl.node.defn = ctrl.node.defn || {};
           return $scope.getProp('search_range') ? CRM.afGuiEditor.dateRanges : CRM.afGuiEditor.dateRanges.slice(1);
         }
@@ -526,7 +526,7 @@
             ctrl.node.defn = ctrl.node.defn || {};
             ctrl.node.defn.afform_default = [];
           }
-          if (_.includes(ctrl.node.defn.afform_default, val)) {
+          if (ctrl.node.defn.afform_default.includes(val)) {
             const newVal = ctrl.node.defn.afform_default.filter((v) => v !== val);
             getSet('afform_default', newVal.length ? newVal : undefined);
             ctrl.hasDefaultValue = !!newVal.length;
@@ -601,7 +601,7 @@
           setFieldDefn();
 
           // When changing the multiple property, force-reset the default value widget
-          if (ctrl.hasDefaultValue && _.includes(['input_type', 'input_attrs.multiple'], propName)) {
+          if (ctrl.hasDefaultValue && ['input_type', 'input_attrs.multiple'].includes(propName)) {
             ctrl.hasDefaultValue = false;
             if (!ctrl.isMultiSelect() && Array.isArray(getSet('afform_default'))) {
               ctrl.node.defn.afform_default = ctrl.node.defn.afform_default[0];

--- a/ext/civi_case/ang/crmCaseType.js
+++ b/ext/civi_case/ang/crmCaseType.js
@@ -413,7 +413,7 @@
 
       var offset = 1;
       var names = $scope.caseType.definition.activitySets.map((activitySet) => activitySet.name);
-      while (_.contains(names, workflow + '_' + offset)) offset++;
+      while (names.includes(workflow + '_' + offset)) offset++;
       activitySet.name = workflow + '_' + offset;
       activitySet.label = (offset == 1  ) ? $scope.workflows[workflow] : ($scope.workflows[workflow] + ' #' + offset);
 
@@ -478,7 +478,7 @@
     /// Add a new top-level activity-type entry
     $scope.addActivityType = function(activityType) {
       var names = $scope.caseType.definition.activityTypes.map((activityType) => activityType.name);
-      if (!_.contains(names, activityType)) {
+      if (!names.includes(activityType)) {
         // Add an activity type that exists
         if ($scope.activityTypes[activityType]) {
           $scope.caseType.definition.activityTypes.push({name: activityType});
@@ -525,7 +525,7 @@
       if (matchingRole) {
         // If it's not in the table already, add it, otherwise do nothing since
         // don't want to add it twice.
-        if (!_.contains(names, matchingRole.xmlName)) {
+        if (!names.includes(matchingRole.xmlName)) {
           roles.push({name: matchingRole.xmlName, displayLabel: matchingRole.text});
         }
       } else {

--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -258,7 +258,7 @@
           excludes = [];
         }
         _.each(MAILING_FIELDS, function (field) {
-          if (!_.contains(excludes, field)) {
+          if (!excludes.includes(field)) {
             mailingTgt[field] = mailingFrom[field];
           }
         });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
@@ -34,7 +34,7 @@
               if (apiCall[1] !== 'save' || ('chain' in apiCall[2] && !_.isEmpty(apiCall[2].chain))) {
                 throw ts('Unsupported API action: only "save" is allowed.');
               }
-              if (!_.includes(allowedEntities, entity)) {
+              if (!allowedEntities.includes(entity)) {
                 throw ts('Unsupported API entity "' + entity + '".');
               }
               if (entity in getCalls) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -186,7 +186,8 @@
           let exprType,
             pos = 0;
           // Add non-field args to the beginning if needed
-          while (!_.includes(ctrl.fn.params[pos].must_be, 'SqlField')) {
+          // Flag-only params (e.g. the unit of EXTRACT) have no must_be; the server strips the empty list
+          while (!(ctrl.fn.params[pos].must_be || []).includes('SqlField')) {
             exprType = _.first(ctrl.fn.params[pos].must_be);
             ctrl.args.splice(pos, 0, {
               type: exprType ? ctrl.exprTypesByType[exprType].name : null,

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayBatch.component.js
@@ -17,11 +17,12 @@
       const ctrl = this;
       $scope.hs = crmUiHelp({file: 'CRM/Search/Help/Display'});
 
-      this.includes = _.includes;
+      // Guarded: the template calls this before settings.classes is necessarily set
+      this.includes = (collection, item) => !!collection && collection.includes(item);
 
       // Add or remove an item from an array
       this.toggle = function(collection, item) {
-        if (_.includes(collection, item)) {
+        if (collection.includes(item)) {
           _.pull(collection, item);
         } else {
           collection.push(item);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -18,7 +18,8 @@
 
 
       // Check if array contains item
-      this.includes = _.includes;
+      // Guarded: the template calls this before settings.classes is necessarily set
+      this.includes = (collection, item) => !!collection && collection.includes(item);
 
       this.getColTypes = function() {
         return ctrl.parent.colTypes;

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTree.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTree.component.js
@@ -22,8 +22,8 @@
 
       this.$onInit = function () {
         // Tree can be draggable if the main entity is a SortableEntity.
-        ctrl.sortableEntity = _.includes(this.parent.getMainEntity().type, 'SortableEntity');
-        ctrl.hierarchicalEntity = _.includes(this.parent.getMainEntity().type, 'HierarchicalEntity');
+        ctrl.sortableEntity = this.parent.getMainEntity().type.includes('SortableEntity');
+        ctrl.hierarchicalEntity = this.parent.getMainEntity().type.includes('HierarchicalEntity');
 
         if (!ctrl.display.settings) {
           ctrl.display.settings = {

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -110,7 +110,7 @@
 
       this.onPostRun.push(function(apiResults) {
         _.each(apiResults.run, function(row) {
-          row.permissionToEdit = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.data.display_acl_bypass, true);
+          row.permissionToEdit = CRM.checkPerm('all CiviCRM permissions and ACLs') || !(row.data.display_acl_bypass || []).includes(true);
           // If someone has manage own permission, we need to override and only allow if they are the owner.
           if (!CRM.checkPerm('administer search_kit') && CRM.checkPerm('manage own search_kit') && (CRM.config.cid !== row.data.created_id)) {
             row.permissionToEdit = false;

--- a/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.component.js
@@ -97,7 +97,7 @@
         const fields = {results: []};
         _.each(searchMeta.getEntity(ctrl.segment.entity_name).fields, function(field) {
           const item = {
-            id: field.name + (field.suffixes && _.includes(field.suffixes, 'name') ? ':name' : ''),
+            id: field.name + (field.suffixes && field.suffixes.includes('name') ? ':name' : ''),
             text: field.label,
             description: field.description
           };

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmMultiSelectDate.directive.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmMultiSelectDate.directive.js
@@ -50,7 +50,7 @@
                         beforeShowDay: function(date) {
                           // Don't allow the same date to be selected twice
                           const dateStr = $.datepicker.formatDate('yy-mm-dd', date);
-                          if (_.includes(existingSelections, dateStr)) {
+                          if (existingSelections.includes(dateStr)) {
                             return [false, '', ''];
                           }
                           return [true, '', ''];

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -37,9 +37,9 @@
             ctrl.dateType = 'range';
           } else if (ctrl.value === 'now') {
             ctrl.dateType = 'now';
-          } else if (_.includes(ctrl.value, 'now -')) {
+          } else if (typeof ctrl.value === 'string' && ctrl.value.includes('now -')) {
             ctrl.dateType = 'now -';
-          } else if (_.includes(ctrl.value, 'now +')) {
+          } else if (typeof ctrl.value === 'string' && ctrl.value.includes('now +')) {
             ctrl.dateType = 'now +';
           } else {
             ctrl.dateType = 'fixed';

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -194,7 +194,7 @@
 
       // @return bool
       isRowSelected: function(row) {
-        return this.allRowsSelected || _.includes(this.selectedRows, row.key);
+        return this.allRowsSelected || this.selectedRows.includes(row.key);
       },
 
       isPageSelected: function() {

--- a/js/Common.js
+++ b/js/Common.js
@@ -237,7 +237,7 @@ if (!CRM.vars) CRM.vars = {};
       var script = document.createElement('script'),
         src = url;
       if (appendCacheCode !== false) {
-        src += (_.includes(url, '?') ? '&r=' : '?r=') + CRM.config.resourceCacheCode;
+        src += (url.includes('?') ? '&r=' : '?r=') + CRM.config.resourceCacheCode;
       }
       scriptsLoaded[url] = $.Deferred();
       script.onload = function () {
@@ -439,7 +439,7 @@ if (!CRM.vars) CRM.vars = {};
         settings.width = '' + parseInt(percentage+gap-((screenWidth - 700)/7*(gap)/100), 10) + '%';
       }
     }
-    if (settings.dialogClass && !_.includes(settings.dialogClass, 'crm-container')) {
+    if (settings.dialogClass && !settings.dialogClass.includes('crm-container')) {
       settings.dialogClass += ' crm-container';
     }
     return settings;
@@ -752,7 +752,7 @@ if (!CRM.vars) CRM.vars = {};
           var staticIds = staticItems.map((item) => item.id),
             idsNeeded = val.split(',').filter((id) => !staticIds.includes(id)),
             existing = _.filter(staticItems, function(item) {
-              return _.includes(val.split(','), item.id);
+              return val.split(',').includes(item.id);
             });
           // If we already have the data, just return it
           if (!idsNeeded.length) {
@@ -899,7 +899,7 @@ if (!CRM.vars) CRM.vars = {};
           var storedIds = stored.map((item) => item.id);
           var idsNeeded = val.split(',').filter((id) => !storedIds.includes(id));
           var existing = _.remove(stored, function(item) {
-            return _.includes(val.split(','), item.id);
+            return val.split(',').includes(item.id);
           });
           // If we already have this data, just return it
           if (!idsNeeded.length) {
@@ -1263,7 +1263,7 @@ if (!CRM.vars) CRM.vars = {};
     if (e.isDefaultPrevented()) {
       return;
     }
-    if (_.contains(submitted, e.target)) {
+    if (submitted.includes(e.target)) {
       return false;
     }
     submitted.push(e.target);

--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -72,8 +72,8 @@
           settings.minDate = settings.minDate ? CRM.utils.makeDate(settings.minDate) : null;
           settings.maxDate = settings.maxDate ? CRM.utils.makeDate(settings.maxDate) : null;
           settings.dateFormat = typeof settings.date === 'string' ? settings.date : CRM.config.dateInputFormat;
-          settings.changeMonth = _.includes(settings.dateFormat, 'm');
-          settings.changeYear = _.includes(settings.dateFormat, 'y');
+          settings.changeMonth = settings.dateFormat.includes('m');
+          settings.changeYear = settings.dateFormat.includes('y');
           if (!settings.yearRange && settings.minDate !== null && settings.maxDate !== null) {
             settings.yearRange = '' + CRM.utils.formatDate(settings.minDate, 'yy') + ':' + CRM.utils.formatDate(settings.maxDate, 'yy');
           }
@@ -129,7 +129,7 @@
           time = null;
         if (context !== 'userInput' && context !== 'crmClear') {
           if (hasDatepicker) {
-            $dateField.datepicker('setDate', _.includes(val, '-') ? $.datepicker.parseDate('yy-mm-dd', val) : null);
+            $dateField.datepicker('setDate', val.includes('-') ? $.datepicker.parseDate('yy-mm-dd', val) : null);
           } else if ($dateField.length) {
             $dateField.val(val.slice(0, 4));
           }

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -570,7 +570,7 @@
 
   function findRecursive(collection, searchTerm) {
     var items = _.filter(collection, function(item) {
-      return item.label && _.includes(item.label.toLowerCase().replace(/ /g, ''), searchTerm);
+      return item.label && item.label.toLowerCase().replace(/ /g, '').includes(searchTerm);
     });
     _.each(collection, function(item) {
       if (_.isPlainObject(item) && item.child) {

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -427,7 +427,7 @@
     },
     isSectionEnabled: function(section) {
       //CRM-15427
-      return (!section || !section.extends_entity_column_value || _.contains(section.extends_entity_column_value, this.get('entity_sub_type')) || this.get('entity_sub_type') == '*');
+      return (!section || !section.extends_entity_column_value || section.extends_entity_column_value.includes(this.get('entity_sub_type')) || this.get('entity_sub_type') == '*');
     },
     getSections: function() {
       var ufEntityModel = this;

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -349,7 +349,7 @@
             treeData.push({
               data: section.title,
               children: items,
-              state: _.contains(paletteView.openTreeNodes, sectionKey) ? 'open' : 'closed',
+              state: paletteView.openTreeNodes.includes(sectionKey) ? 'open' : 'closed',
               attr: {
                 'class': 'crm-designer-palette-section',
                 'data-section': sectionKey,

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -149,7 +149,7 @@
    * @param name string
    */
   function addField(name) {
-    $('#api-params').append($(fieldTpl({name: name || '', noOps: _.includes(NO_OPERATORS, action)})));
+    $('#api-params').append($(fieldTpl({name: name || '', noOps: NO_OPERATORS.includes(action)})));
     var $row = $('tr:last-child', '#api-params');
     $('input.api-param-name', $row).crmSelect2({
       data: selectFields,
@@ -309,7 +309,7 @@
       populateFields(fields, entity, action, '', required);
       showFields(required);
       renderJoinSelector();
-      if (_.includes(['get', 'getsingle', 'getvalue', 'getstat', 'gettree'], action)) {
+      if (['get', 'getsingle', 'getvalue', 'getstat', 'gettree'].includes(action)) {
         showReturn();
       }
     });
@@ -385,8 +385,8 @@
       formatResult: renderAction
     });
     // If previously selected action is not available, set it to 'get' if possible
-    if (!_.includes(actions.values, val)) {
-      $('#api-action').select2('val', !_.includes(actions.values, 'get') ? actions.values[0] : 'get', true);
+    if (!actions.values.includes(val)) {
+      $('#api-action').select2('val', !actions.values.includes('get') ? actions.values[0] : 'get', true);
     }
   }
 
@@ -427,7 +427,7 @@
    */
   function isSelect(fieldName, operator) {
     var fieldSpec = getField(fieldName);
-    return (isYesNo(fieldName) || fieldSpec.options || fieldSpec.FKApiName) && !_.includes(TEXT, operator);
+    return (isYesNo(fieldName) || fieldSpec.options || fieldSpec.FKApiName) && !TEXT.includes(operator);
   }
 
   /**
@@ -438,10 +438,10 @@
    * @returns boolean
    */
   function isMultiSelect(fieldName, operator) {
-    if (isYesNo(fieldName) || _.includes(NO_MULTI, action)) {
+    if (isYesNo(fieldName) || NO_MULTI.includes(action)) {
       return false;
     }
-    if (_.includes(MULTI, operator)) {
+    if (MULTI.includes(operator)) {
       return true;
     }
     // The = operator is ambiguous but all others can be safely assumed to be single
@@ -476,7 +476,7 @@
     }
     $valField.attr('placeholder', ts('Value'));
     // Boolean fields only have 1 possible value
-    if (_.includes(BOOL, operator)) {
+    if (BOOL.includes(operator)) {
       $valField.css('visibility', 'hidden').val('1');
       return;
     }
@@ -489,7 +489,8 @@
         $valField.val('');
       }
       // When switching from multi-select to single select
-      else if (!multiSelect && _.includes(currentVal, ',')) {
+      // $valField was a multi-select, so val() gives null when nothing was selected
+      else if (!multiSelect && (currentVal || '').includes(',')) {
         $valField.val(currentVal.split(',')[0]);
       }
       // Yes-No options
@@ -515,7 +516,7 @@
           entity: entity,
           select: {
             multiple: multiSelect,
-            minimumInputLength: _.includes(OPEN_IMMEDIATELY, entity) ? 0 : 1,
+            minimumInputLength: OPEN_IMMEDIATELY.includes(entity) ? 0 : 1,
             // If user types a numeric id, allow it as a choice
             createSearchChoice: function(input) {
               var match = /[1-9][0-9]*/.exec(input);
@@ -610,7 +611,7 @@
         op = $('select.api-param-op', $row).val() || '=',
         name = $('input.api-param-name', $row).val(),
         // Workaround for ambiguity of the = operator
-        makeArray = (op === '=' && isSelect(name, op)) ? _.includes(input, ',') : op !== '=' && isMultiSelect(name, op),
+        makeArray = (op === '=' && isSelect(name, op)) ? input.includes(',') : op !== '=' && isMultiSelect(name, op),
         val = evaluate(input, makeArray);
 
       // Ignore blank values for the return field
@@ -729,7 +730,7 @@
     q.php += ");";
     q.json += ").then(function(result) {\n  // do something with result\n}, function(error) {\n  // oops\n});";
     q.smarty += "}\n{foreach from=$result.values item=" + entity.toLowerCase() + "}\n  {$" + entity.toLowerCase() + ".some_field}\n{/foreach}";
-    if (!_.includes(action, 'get')) {
+    if (!action.includes('get')) {
       q.smarty = '{* Smarty API only works with get actions *}';
     }
     $('#api-rest').html(restTpl(http));
@@ -749,7 +750,7 @@
       alert(ts('Select an entity.'));
       return;
     }
-    if (!_.includes(action, 'get') && !_.includes(action, 'check')) {
+    if (!action.includes('get') && !action.includes('check')) {
       var msg = action === 'delete' ? ts('This will delete data from CiviCRM. Are you sure?') : ts('This will write to the database. Continue?');
       CRM.confirm({title: ts('Confirm %1', {1: action}), message: msg}).on('crmConfirm:yes', execute);
     } else {
@@ -771,7 +772,7 @@
         prettyprint: 1,
         json: JSON.stringify(params)
       },
-      type: _.includes(action, 'get') ? 'GET' : 'POST',
+      type: action.includes('get') ? 'GET' : 'POST',
       dataType: 'text'
     }).then(function(text) {
       $('#api-result').text(text);
@@ -833,7 +834,7 @@
    */
   function renderJoinSelector() {
     $('#api-join').hide();
-    if (!_.includes(NO_JOINS, entity) && _.includes(['get', 'getsingle', 'getcount'], action)) {
+    if (!NO_JOINS.includes(entity) && ['get', 'getsingle', 'getcount'].includes(action)) {
       var joinable = {};
       (function recurse(fields, joinable, prefix, depth, entities) {
         _.each(fields, function(field) {
@@ -893,7 +894,7 @@
   }
 
   function handleAndOr() {
-    if (!_.includes(NO_JOINS, entity) && _.includes(['get', 'getsingle', 'getcount'], action)) {
+    if (!NO_JOINS.includes(entity) && ['get', 'getsingle', 'getcount'].includes(action)) {
       var or = [];
       $('tr.api-param-row').each(function() {
         if ($(this).next().is('tr.api-param-row') && $('input.api-param-name', this).val()) {


### PR DESCRIPTION
Overview
----------------------------------------

Replaces every `_.includes()` and `_.contains()` call in core JavaScript with the native `Array.prototype.includes` / `String.prototype.includes`, continuing the move away from lodash.

`_.contains` is an alias that only exists in the `lodash-compat` bundle, so this also chips away at what that bundle is still needed for.

Before
----------------------------------------

59 calls across 24 files, in three shapes — array membership, substring tests, and a couple bound straight into a template:

```js
if (_.contains(names, activityType)) { … }
settings.changeMonth = _.includes(settings.dateFormat, 'm');
this.includes = _.includes;
```

After
----------------------------------------

```js
if (names.includes(activityType)) { … }
settings.changeMonth = settings.dateFormat.includes('m');
this.includes = (collection, item) => !!collection && collection.includes(item);
```

No user-visible change.

Technical Details
----------------------------------------

`_.includes` and the native methods both use SameValueZero, and both behave identically on arrays and on strings, so the majority of these are a straight swap.

They differ in one respect that matters: lodash treats a `null` or `undefineturns `false`, whereas the native method throws. Five sites can genuinelyreceive one, and are guarded rather than swapped blindly:

| Site | Why |
| --- | --- |
| `crmSearchAdminSearchListing` | `display_acl_bypass` is `null` for a saved
| `searchAdminDisplayBatch`, `searchAdminDisplayTable` | the `includes` helper is bound into the template and called before `settings.classes` is necessarily set |
| `crmSearchInputVal` | the filter value is not always a string |
| `APIExplorer` | `$valField.val()` returns `null` for a multi-select with n

The `display_acl_bypass` one is not hypothetical — I confirmed against the API that it comes back `null` whenever a saved search has no displays, so an unguarded conversion would have thrown for every such row in the SearchKit listing.

One judgement call worth surfacing: `crmSearchFunction`'s `while (!…must_be.includes('SqlField'))` was converted plain. If `must_be` were ever absent, the lodash version already
walked off the end of `params` and crashed on the next iteration, so there ihe native call could break — only a slightly earlier error.

Comments
----------------------------------------

Tested manually against a Standalone build, with no console errors:

- **APIv3 Explorer** (19 of the conversions) — entity and action selection,  the operator to `IN` and back to `=` (which is exactly the empty-multi-select case above), and executing the call. All six generated code blocks render.
- **SearchKit** — the saved-search listing with a display-less search present; the display Style class checkboxes reading and toggling correctly; the search input's relative-date branches.
- **Core** — the datepicker round-tripping `2020-05-06` into `05/06/2020` (ecks and the ISO branch); `CRM.menubar.findItems()` matching "New Individual"and "Manage Tags" and returning nothing for a non-match.
- **Afform** — the field settings panel, including the default-value path.
- **CiviCase** — the Case Type editor's unique-name loop, which produced `timeline_1` and `timeline_2` as expected.

Not individually exercised, all plain membership tests against locally-built or explicitly-defaulted arrays: `exportui`, `civi_mail` services, `crm.uf`, `crm.designer`, `crmEntityTags`, `crmUtil`, `afGuiContainer`, `afGuiEditor`, `searchAdminDisplayTree`, `crmSearchAdminImport`, `crmMultiSelectDate`, `crmSearchAdminSegment`, `searchDisplayTasksTrait`.