### PR TITLE
[dev/core#6749] Fix warning relating to missing array element "task"

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -331,7 +331,7 @@ class CRM_Core_Invoke {
       ];
     }
     else {
-      $newArgs = explode('/', $_GET[$config->userFrameworkURLVar]);
+      $newArgs = explode('/', $_GET[$config->userFrameworkURLVar] ?? '');
       $mode = 'null';
       if (isset($pageArgs['mode'])) {
         $mode = $pageArgs['mode'];
@@ -340,7 +340,7 @@ class CRM_Core_Invoke {
       $title = $item['title'] ?? NULL;
       if (str_contains($item['page_callback'], '_Page') || str_contains($item['page_callback'], '\\Page\\')) {
         $object = new $item['page_callback']($title, $mode);
-        $object->urlPath = explode('/', $_GET[$config->userFrameworkURLVar]);
+        $object->urlPath = $newArgs;
       }
       elseif (str_contains($item['page_callback'], '_Controller') || str_contains($item['page_callback'], '\\Controller\\')) {
         $addSequence = 'false';


### PR DESCRIPTION
Overview
----------------------------------------
Fix for [dev/core#6749](https://lab.civicrm.org/dev/core/-/work_items/6749).

Before
----------------------------------------
Repeated warnings in `error_log` as follows:

```
[08-Sep-2026 13:26:04 Europe/London] PHP Warning:  Undefined array key "task" in /home/csesorgu/public_html/administrator/components/com_civicrm/civicrm/CRM/Core/Invoke.php on line 368
[08-Sep-2026 13:26:04 Europe/London] PHP Warning:  Undefined array key "task" in /home/csesorgu/public_html/administrator/components/com_civicrm/civicrm/CRM/Core/Invoke.php on line 377
```

After
----------------------------------------
Warnings disappear.

Technical Details
----------------------------------------
Occurs when the `'task'` element is missing from `$_GET`, which could occur anytime because this is uncontrolled user input. Adds null coalescence to handle this case.

Comments
----------------------------------------
N/A
