### PR TITLE
Stop passing fields into createProfileContact for billing

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -536,20 +536,9 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected function processBillingAddress(int $contactID, string $email): void {
-    $fields = [];
-
-    $fields['email-Primary'] = 1;
     $this->_params['email-5'] = $this->_params['email-Primary'] = $email;
-    $billingLocationID = CRM_Core_BAO_LocationType::getBilling();
-    $fields["address_name-{$billingLocationID}"] = 1;
-
-    //ensure we don't over-write the payer's email with the member's email
-    if ($contactID == $this->_contactID) {
-      $fields["email-{$billingLocationID}"] = 1;
-    }
 
     [$hasBillingField, $addressParams] = CRM_Contribute_BAO_Contribution::getPaymentProcessorReadyAddressParams($this->_params);
-    $fields = $this->formatParamsForPaymentProcessor($fields);
 
     if ($hasBillingField) {
       $addressParams = array_merge($this->_params, $addressParams);
@@ -562,7 +551,7 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
       //here we are setting up the billing contact - if different from the member they are already created
       // but they will get billing details assigned
       $addressParams['contact_id'] = $contactID;
-      CRM_Contact_BAO_Contact::createProfileContact($addressParams, $fields,
+      CRM_Contact_BAO_Contact::createProfileContact($addressParams, [],
         $contactID, NULL, NULL,
         CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'contact_type')
       );

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1239,7 +1239,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // At this point we've created a contact and stored its address etc
     // all the payment processors expect the name and address to be in the
     // so we copy stuff over to first_name etc.
-    $paymentParams = $this->_params;
+    $paymentParams = $this->prepareParamsForPaymentProcessor($this->_params);
     $paymentParams['contactID'] = $contactID;
     CRM_Core_Payment_Form::mapParams(NULL, $this->_params, $paymentParams, TRUE);
 

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1088,7 +1088,8 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       // at this point we've created a contact and stored its address etc
       // all the payment processors expect the name and address to be in the
       // so we copy stuff over to first_name etc.
-      $paymentParams = $formValues;
+      // @todo formValues might not need to be merged in.
+      $paymentParams = $this->prepareParamsForPaymentProcessor($this->getSubmittedValues()) + $formValues;
       $paymentParams['frequency_unit'] = $this->getFrequencyUnit();
       $paymentParams['frequency_interval'] = $this->getFrequencyInterval();
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -521,7 +521,8 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       // at this point we've created a contact and stored its address etc
       // all the payment processors expect the name and address to be in the passed params
       // so we copy stuff over to first_name etc.
-      $paymentParams = $this->_params;
+      // @todo - probably do not need to add in _params - just need to check what we added above.
+      $paymentParams = $this->prepareParamsForPaymentProcessor($this->getSubmittedValues()) + $this->_params;
       if ($this->getSubmittedValue('send_receipt')) {
         $paymentParams['email'] = $this->_contributorEmail;
       }


### PR DESCRIPTION


Overview
----------------------------------------
Stop passing fields into createProfileContact for billing

It is ignored - this also adds calls to prepareParamsForPaymentProcessor in the calling forms so they don't suffer from it being removed

Before
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/36782 I did the analysis to determine that $fields does not get used when processing billing profiles

After
----------------------------------------
No longer calculated & passed in - as the AbstractEditPayment was incidentally passing `_params` through `prepareParamsForPaymentProcessor()` I explictly made sure it was still called to gather paymentParams 

Technical Details
----------------------------------------
There is further consolidation on `prepareParamsForPaymentProcessor()` that I can do as a follow up - it almost exactly duplicates `Payment_Form::mapParams()` so once this is merged I will address

Comments
----------------------------------------
