### PR TITLE
searchkit: Add .ng-dirty to CSS validation borders

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -479,8 +479,8 @@ input.crm-form-checkbox) + label {
   align-items: center;
   margin-right: 0;
 }
-.crm-container .select2-container-multi.ng-invalid .select2-choices,
-.crm-container .select2-container.ng-invalid .select2-choice {
+.crm-container .select2-container-multi.ng-dirty.ng-invalid .select2-choices,
+.crm-container .select2-container.ng-dirty.ng-invalid .select2-choice {
   border-color: var(--crm-warning-color);
 }
 .crm-container .select2-container .select2-choice .select2-arrow {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -23,9 +23,9 @@ form.crm-search-display-page {
 .crm-search-display th:not(:hover) i.fa-sort {
   opacity: .5;
 }
-.crm-search input.ng-invalid,
-.crm-search-display input.ng-invalid,
-.crm-search-task-dialog input.ng-invalid {
+.crm-search input.ng-dirty.ng-invalid,
+.crm-search-display input.ng-dirty.ng-invalid,
+.crm-search-task-dialog input.ng-dirty.ng-invalid {
   border-color: var(--crm-warning-color);
 }
 .crm-search-display button.dropdown-toggle {

--- a/ext/search_kit/css/crmSearchDisplay.css
+++ b/ext/search_kit/css/crmSearchDisplay.css
@@ -10,9 +10,9 @@
   opacity: .5;
 }
 
-#bootstrap-theme.crm-search input.ng-invalid,
-#bootstrap-theme.crm-search-display input.ng-invalid,
-.crm-search-task-dialog #bootstrap-theme input.ng-invalid {
+#bootstrap-theme.crm-search input.ng-dirty.ng-invalid,
+#bootstrap-theme.crm-search-display input.ng-dirty.ng-invalid,
+.crm-search-task-dialog #bootstrap-theme input.ng-dirty.ng-invalid {
   border-color: #8a1f11;
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
This CSS fix was identified while working on #35896. Rather than bundle it with the larger Register Event feature, I'm breaking it out as a standalone fix.

This change adds .ng-dirty to CSS selectors in both the riverlea and bootstrap themes, bringing them in line with the pattern already used in core's https://github.com/civicrm/civicrm-core/blob/bb32983772b308893e9e32a34716d2e7a958cda5/css/civicrm.css#L4018

@vingle This came up in the original PR and I believe you had some thoughts on it.

Before
----------------------------------------
Red borders appear on all invalid fields immediately on dialog load (e.g. "Update Contact" and "Add Relationship" task dialogs).
<img width="712" height="159" alt="Screenshot From 2026-09-09 19-37-41" src="https://github.com/user-attachments/assets/904b65a9-7f0b-4d3a-affe-83ac91357798" />
<img width="1224" height="203" alt="Screenshot From 2026-09-09 19-34-58" src="https://github.com/user-attachments/assets/4430a802-2b84-472c-842f-a5ca0821f2ff" />
<img width="1224" height="235" alt="Screenshot From 2026-09-09 20-18-44" src="https://github.com/user-attachments/assets/8a9183ce-0962-4ba5-be9b-1bb695e10661" />



After
----------------------------------------
Red borders only appear after the user has touched and left a field empty.
<img width="719" height="158" alt="Screenshot From 2026-09-09 20-21-08" src="https://github.com/user-attachments/assets/57174075-7e5e-4c4e-b2c4-a0da0d2ff615" />
<img width="1224" height="207" alt="Screenshot From 2026-09-09 20-14-24" src="https://github.com/user-attachments/assets/c4c933a1-dea8-4ff6-82f6-b9d529ae7910" />
<img width="1224" height="235" alt="Screenshot From 2026-09-09 20-18-58" src="https://github.com/user-attachments/assets/975c5eaa-1896-4b8e-a439-bdd7dd13522f" />
