### PR TITLE
Handle currency consistently in event registration

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -520,7 +520,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     $vars = [
       'amount',
-      'currencyID',
       'credit_card_type',
       'trxn_id',
       'amount_level',
@@ -540,6 +539,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         $this->assign($v, $params[$v] ?? NULL);
       }
     }
+    $this->assign('currencyID', $this->getCurrency());
 
     $this->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params));
 
@@ -876,7 +876,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       'fee_amount' => $params['fee_amount'] ?? NULL,
       'registered_by_id' => $params['registered_by_id'] ?? NULL,
       'discount_id' => $params['discount_id'] ?? NULL,
-      'fee_currency' => $params['currencyID'] ?? NULL,
+      'fee_currency' => $this->getCurrency(),
       'campaign_id' => $params['campaign_id'] ?? NULL,
       'is_test' => $this->isTest(),
     ];
@@ -1891,8 +1891,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       // Is this valid? It comes from previously shared code.
       $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
     }
-    // @todo If empty there is a problem - we should probably put in a deprecation notice
-    // to warn if that seems to be happening.
+    if (empty($currency)) {
+      $currency = \Civi::settings()->get('defaultCurrency');
+    }
     return $currency;
   }
 

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -695,9 +695,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
       }
     }
     else {
-
-      $config = CRM_Core_Config::singleton();
-      $params['currencyID'] = $config->defaultCurrency;
+      $params['currencyID'] = $this->getCurrency();
 
       if ($this->isPaidEvent()) {
 

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -210,7 +210,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       }
 
       $params['amount_level'] = $this->_params[0]['amount_level'];
-      $params['currencyID'] = $this->_params[0]['currencyID'];
 
       // also merge all the other values from the profile fields
       $values = $this->controller->exportValues('Register');
@@ -502,7 +501,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       }
     }
     $taxAmount = $totalTaxAmount;
-    $payment = $registerByID = $primaryCurrencyID = $contribution = NULL;
+    $payment = $registerByID = $contribution = NULL;
     $paymentObjError = ts('The system did not record payment details for this payment and so could not process the transaction. Please report this error to the site administrator.');
 
     $fields = [];
@@ -637,14 +636,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
 
       if (!empty($participantRecord['contributionID'])) {
         $this->_values['contributionId'] = $participantRecord['contributionID'];
-      }
-
-      //CRM-4453.
-      if (!empty($participantRecord['is_primary'])) {
-        $primaryCurrencyID = $participantRecord['currencyID'] ?? NULL;
-      }
-      if (empty($participantRecord['currencyID'])) {
-        $participantRecord['currencyID'] = $primaryCurrencyID;
       }
 
       // CRM-11182 - Confirmation page might not be monetary
@@ -902,7 +893,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       'tax_amount' => $params['tax_amount'],
       'amount_level' => $params['amount_level'],
       'invoice_id' => $params['invoiceID'],
-      'currency' => $params['currencyID'],
+      'currency' => $this->getCurrency(),
       'source' => !empty($params['participant_source']) ? $params['participant_source'] : $params['description'],
       'is_pay_later' => $params['is_pay_later'] ?? 0,
       'campaign_id' => $params['campaign_id'] ?? NULL,

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -754,8 +754,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $params['participant_role_id'] = $this->_values['event']['default_role_id'];
     }
 
-    $config = CRM_Core_Config::singleton();
-    $params['currencyID'] = $config->defaultCurrency;
+    $params['currencyID'] = $this->getCurrency();
 
     if ($this->isPaidEvent()) {
       // we first reset the confirm page so it accepts new values
@@ -803,7 +802,6 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       $this->set('contributeMode', 'direct');
 
       if ($this->isPaidEvent()) {
-        $params['currencyID'] = $config->defaultCurrency;
         $params['invoiceID'] = $invoiceID;
       }
       $this->_params = $this->get('params');


### PR DESCRIPTION
This switches to always using the helper rather than hard to trace approaches.

The helper prefers the event currency but falls back to the default.

Specific cover in CRM_Event_Form_Registration_ConfirmTest::testWaitlistRegistrationContactIDParam
