### PR TITLE
Replace lodash _.extend/_.assign with Object.assign

### DIFF
--- a/ang/crmAttachment.js
+++ b/ang/crmAttachment.js
@@ -65,7 +65,7 @@
           throw "Cannot save attachments: unknown entity_table or entity_id";
         }
 
-        var params = _.extend({}, target);
+        var params = Object.assign({}, target);
         params.values = crmAttachments.files;
         return crmApi('Attachment', 'replace', params)
           .then(function () {
@@ -74,7 +74,7 @@
             var newItems = crmAttachments.uploader.getNotUploadedItems();
             if (newItems.length > 0) {
               _.each(newItems, function (item) {
-                item.formData = [_.extend({crm_attachment_token: CRM.crmAttachment.token}, target, item.crmData)];
+                item.formData = [Object.assign({crm_attachment_token: CRM.crmAttachment.token}, target, item.crmData)];
               });
               crmAttachments.uploader.onCompleteAll = function onCompleteAll() {
                 delete crmAttachments.uploader.onCompleteAll;

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -1207,7 +1207,7 @@
               return;
             }
 
-            CRM.confirm(_.extend(defaults, options))
+            CRM.confirm(Object.assign(defaults, options))
               .on('crmConfirm:yes', function() { scope.$apply(attrs.onYes); })
               .on('crmConfirm:no', function() { scope.$apply(attrs.onNo); });
 

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -173,7 +173,7 @@
           });
           // Add behavior data
           CRM.afGuiEditor.behaviors = CRM.afGuiEditor.behaviors || {};
-          _.extend(CRM.afGuiEditor.behaviors, data.behaviors);
+          Object.assign(CRM.afGuiEditor.behaviors, data.behaviors);
           // Add entities
           _.each(data.entities, function(entity, entityName) {
             if (!CRM.afGuiEditor.entities[entityName]) {
@@ -191,7 +191,7 @@
           });
         },
 
-        meta: _.extend(CRM.afGuiEditor, CRM.afAdmin),
+        meta: Object.assign(CRM.afGuiEditor, CRM.afAdmin),
 
         getEntity: getEntity,
 

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -85,7 +85,7 @@
       ];
 
       // Above mode for use with getterSetter
-      this.debounceWithGetterSetter = _.assign({getterSetter: true}, this.debounceMode);
+      this.debounceWithGetterSetter = Object.assign({getterSetter: true}, this.debounceMode);
 
       this.$onInit = function() {
         // Load the current form plus blocks & fields
@@ -382,7 +382,8 @@
         while (!!$scope.entities[type + num]) {
           num++;
         }
-        $scope.entities[type + num] = backfillEntityDefaults(_.assign($parse(meta.defaults)(editor), {
+        // $parse returns undefined for entities with no `defaults` metadata
+        $scope.entities[type + num] = backfillEntityDefaults(Object.assign($parse(meta.defaults)(editor) || {}, {
           '#tag': 'af-entity',
           type: meta.entity,
           name: type + num,
@@ -499,7 +500,7 @@
       function getPlacementEntitiesFromMeta(metaPlacements) {
         const placements = {};
         metaPlacements.forEach((item) => {
-          _.extend(placements, editor.meta.placement_entities[item.id]);
+          Object.assign(placements, editor.meta.placement_entities[item.id]);
         });
         return placements;
       }

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -482,7 +482,7 @@
           if (ctrl.fileUploader.getNotUploadedItems().length) {
             _.each(ctrl.fileUploader.getNotUploadedItems(), function(file) {
               file.formData.push({
-                params: JSON.stringify(_.extend({
+                params: JSON.stringify(Object.assign({
                   token: response[0].token,
                   name: ctrl.getFormMeta().name
                 }, file.crmApiParams()))
@@ -527,7 +527,7 @@
             uploadingDraftFiles = true;
             ctrl.fileUploader.getNotUploadedItems().forEach((file) => {
               file.formData.push({
-                params: JSON.stringify(_.extend({
+                params: JSON.stringify(Object.assign({
                   name: ctrl.getFormMeta().name
                 }, file.crmApiParams()))
               });

--- a/ext/civi_mail/ang/crmMailing/SaveMsgTemplateDialogCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/SaveMsgTemplateDialogCtrl.js
@@ -14,7 +14,7 @@
     $scope.selected = null;
 
     $scope.save = function save() {
-      const tpl = _.extend({}, $scope.model.tpl);
+      const tpl = Object.assign({}, $scope.model.tpl);
       switch ($scope.saveOpt.mode) {
         case 'add':
           tpl.msg_title = $scope.saveOpt.newTitle;

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -222,7 +222,7 @@
           }
         }
         const defaultLabel = labels.join(' - ');
-        result = _.assign(structuredClone(join), {
+        result = Object.assign(structuredClone(join), {
           label: (savedSearch && savedSearch.form_values && savedSearch.form_values.join && savedSearch.form_values.join[alias]) || defaultLabel,
           defaultLabel: defaultLabel,
           alias: alias,

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -26,7 +26,7 @@
 
       this.$onInit = function () {
         if (!ctrl.display.settings) {
-          ctrl.display.settings = _.extend({}, structuredClone(CRM.crmSearchAdmin.defaultDisplay.settings), {columns: null, pager: {}});
+          ctrl.display.settings = Object.assign({}, structuredClone(CRM.crmSearchAdmin.defaultDisplay.settings), {columns: null, pager: {}});
           ctrl.display.settings.sort = ctrl.parent.getDefaultSort();
         }
         // Displays created prior to 5.43 may not have this property

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -227,7 +227,7 @@
       },
 
       getFilters: function() {
-        return _.assign({}, this.getAfformFilters(), this.filters);
+        return Object.assign({}, this.getAfformFilters(), this.filters);
       },
 
       getAfformFilters: function() {

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -208,7 +208,7 @@
           const mngr = this.taskManager;
           event.preventDefault();
           mngr.getMetadata().then(function() {
-            mngr.doTask(_.extend({title: link.title}, mngr.getTaskInfo(link.task)), [id], true);
+            mngr.doTask(Object.assign({title: link.title}, mngr.getTaskInfo(link.task)), [id], true);
           });
         }
       },

--- a/js/Common.js
+++ b/js/Common.js
@@ -706,12 +706,12 @@ if (!CRM.vars) CRM.vars = {};
         quickAddLinks = getQuickAddLinks(select2Options.quickAdd),
         multiple = !!select2Options.multiple;
 
-      $el.crmSelect2(_.extend({
+      $el.crmSelect2(Object.assign({
         ajax: {
           quietMillis: 250,
           url: CRM.url('civicrm/ajax/api4/' + entityName + '/autocomplete'),
           data: function (input, page, context) {
-            return {params: JSON.stringify(_.assign({
+            return {params: JSON.stringify(Object.assign({
               input: input,
               searchField: context && context.searchField || null,
               exclude: context && context.previousIds || null,
@@ -1696,7 +1696,7 @@ if (!CRM.vars) CRM.vars = {};
   CRM.addStrings = function(domain, strings) {
     var bucket = (domain == 'civicrm' ? 'strings' : 'strings::' + domain);
     CRM[bucket] = CRM[bucket] || {};
-    _.extend(CRM[bucket], strings);
+    Object.assign(CRM[bucket], strings);
   };
 
   /**

--- a/js/crm.backbone.js
+++ b/js/crm.backbone.js
@@ -140,7 +140,7 @@
       }
     });
     // Overrides - if specified in ModelClass, replace
-    _.extend(ModelClass.prototype, {
+    Object.assign(ModelClass.prototype, {
       sync: CRM.Backbone.sync
     });
   };
@@ -202,7 +202,7 @@
     });
 
     // Overrides - if specified in ModelClass, replace
-    _.extend(ModelClass.prototype, {
+    Object.assign(ModelClass.prototype, {
       initialize: function(options) {
         this._modified = false;
         this._oldModified = [];
@@ -259,7 +259,7 @@
     });
 
     // Overrides - if specified in ModelClass, replace
-    _.extend(ModelClass.prototype, {
+    Object.assign(ModelClass.prototype, {
       save: function(attributes, options) {
         if (this.isSoftDeleted()) {
           return this.destroy(options);
@@ -321,7 +321,7 @@
         return this.crmActions[action] ? this.crmActions[action] : action;
       },
       toCrmCriteria: function() {
-        var result = (this.crmCriteria) ? _.extend({}, this.crmCriteria) : {};
+        var result = (this.crmCriteria) ? Object.assign({}, this.crmCriteria) : {};
         if (!_.isEmpty(this.crmReturn)) {
           result.return = this.crmReturn;
         } else if (this.model && !_.isEmpty(this.model.prototype.crmReturn)) {
@@ -374,7 +374,7 @@
       }
     });
     // Overrides - if specified in CollectionClass, replace
-    _.extend(CollectionClass.prototype, {
+    Object.assign(CollectionClass.prototype, {
       sync: CRM.Backbone.sync,
       initialize: function(models, options) {
         if (!options) options = {};
@@ -384,7 +384,7 @@
           this.crmCriteria = options.crmCriteria;
         }
         if (options.crmActions) {
-          this.crmActions = _.extend(this.crmActions, options.crmActions);
+          this.crmActions = Object.assign(this.crmActions, options.crmActions);
         }
         if (origInit) {
           return origInit.apply(this, arguments);
@@ -423,7 +423,7 @@
      collection.fetch({
       success: function(collection) {
         if (collection.length === 0) {
-          var attrs = _.extend({}, collection.crmCriteria, options.defaults || {});
+          var attrs = Object.assign({}, collection.crmCriteria, options.defaults || {});
           var model = collection._prepareModel(attrs, options);
           options.success(model);
         } else if (collection.length == 1) {

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -4,7 +4,7 @@
   var templates, initialized,
     ENTER_KEY = 13,
     SPACE_KEY = 32;
-  CRM.menubar = _.extend({
+  CRM.menubar = Object.assign({
     data: null,
     settings: {collapsibleBehavior: 'accordion'},
     position: 'over-cms-menu',
@@ -218,7 +218,7 @@
       if (!menuItem) {
         throw item.name + ' not found';
       }
-      _.extend(menuItem, item);
+      Object.assign(menuItem, item);
       $('li[data-name="' + item.name + '"]', '#civicrm-menu').replaceWith(getTpl('branch')({items: [menuItem], branchTpl: getTpl('branch')}));
       CRM.menubar.refresh();
     },


### PR DESCRIPTION
Overview
----------------------------------------
Continues the removal of lodash from core JS by replacing all 26 remaining `_.extend()` and `_.assign()` calls with native `Object.assign()`.

Before
----------------------------------------
26 calls across 13 files, e.g.:

```js
var params = _.extend({}, target);
_.extend(ModelClass.prototype, {sync: CRM.Backbone.sync});
return _.assign({}, this.getAfformFilters(), this.filters);
```

After
----------------------------------------
```js
var params = Object.assign({}, target);
Object.assign(ModelClass.prototype, {sync: CRM.Backbone.sync});
return Object.assign({}, this.getAfformFilters(), this.filters);
```

Technical Details
----------------------------------------
`_.assign()` is `Object.assign()`. `_.extend()` is lodash's `assignIn()`, which differs only in also copying **inherited** enumerable properties from its sources — every source here is a plain object literal, a JSON-derived object or an API response, so there is nothing inherited to copy.

The one behavioural difference that needed handling is a **null/undefined target**: lodash coerces it to `{}` via `Object(object)`, while `Object.assign()` throws. Every target was traced; only `afGuiEditor.addEntity()` can hit it, where `$parse(meta.defaults)(editor)` returns `undefined` for entities with no `defaults` metadata, so that call gets an explicit `|| {}`. Null/undefined *sources* are ignored by both, so the many `_.extend({...}, maybeUndefined)` calls need no guard.

Files touched: `ang/crmAttachment.js`, `ang/crmUi.js`, `ext/afform/admin/ang/afGuiEditor.js`, `ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js`, `ext/afform/core/ang/af/afForm.component.js`, `ext/civi_mail/ang/crmMailing/SaveMsgTemplateDialogCtrl.js`, `ext/search_kit/ang/crmSearchAdmin.module.js`, `ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js`, `ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js`, `ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js`, `js/Common.js`, `js/crm.backbone.js`, `js/crm.menubar.js`.

Comments
----------------------------------------
Karma suite green (81/81, run 5 times). Manually exercised in a standalone sandbox: menubar rendering plus `CRM.menubar.updateItem()` and `CRM.addStrings()`; the Form Builder editor adding entities both with and without `defaults` metadata, and the placement-entity list; SearchKit adding a bridged join (label + numbered join conditions), running the search, and creating a Table display with default settings; and all four `crm.backbone.js` prototype configurators (`extendModel`, `trackSaved`, `trackSoftDelete`, `extendCollection`) plus `toCrmCriteria()`/`toCrmAction()` driven from the console. No console errors.
