### PR TITLE
Replace lodash _.keys/_.values with Object.keys/Object.values

### DIFF
--- a/ang/crmAttachment.js
+++ b/ang/crmAttachment.js
@@ -46,7 +46,7 @@
             entity_id: target.entity_id
           };
           return crmApi('Attachment', 'get', params).then(function (apiResult) {
-            Attachment.files = _.values(apiResult.values);
+            Attachment.files = Object.values(apiResult.values);
             return Attachment;
           });
         }

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -275,7 +275,7 @@
                 name: bridgeEntity.entity,
                 prefix: joinInfo[1] + '.',
                 label: formValues.join[joinInfo[1]] + ' ' + bridgeEntity.label,
-                fields: _.omit(bridgeEntity.fields, _.keys(entity.fields)),
+                fields: _.omit(bridgeEntity.fields, Object.keys(entity.fields || {})),
               });
             }
           });

--- a/ext/civi_case/ang/crmCaseType.js
+++ b/ext/civi_case/ang/crmCaseType.js
@@ -533,7 +533,7 @@
          // At this point roleIdOrLabel must be the new label they just typed.
          CRM.loadForm(CRM.url('civicrm/admin/reltype', {action: 'add', reset: 1, label_a_b: roleIdOrLabel}))
           .on('crmFormSuccess', function(e, data) {
-            var newType = _.values(data.relationshipType)[0];
+            var newType = Object.values(data.relationshipType)[0];
             $scope.$apply(function() {
               $scope.addRoleOnTheFly(roles, newType);
             });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
@@ -49,7 +49,7 @@
                 getCalls[entity] = [entity, 'get', {select: ['row_count'], where: where}];
               }
             });
-            if (_.keys(getCalls).length < 2) {
+            if (Object.keys(getCalls).length < 2) {
               throw ts('No records to import.');
             }
             crmApi4(getCalls)

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -74,8 +74,8 @@
         const param = ctrl.getParam(ctrl.args.length);
         ctrl.args.push({
           type: ctrl.exprTypesByType[sqlExprType].name,
-          flag_before: _.filter(_.keys(param.flag_before))[0],
-          flag_after: _.filter(_.keys(param.flag_after))[0],
+          flag_before: Object.keys(param.flag_before || {}).filter(Boolean)[0],
+          flag_after: Object.keys(param.flag_after || {}).filter(Boolean)[0],
           name: param.name,
           value: '',
           optional: optional,
@@ -190,8 +190,8 @@
             exprType = _.first(ctrl.fn.params[pos].must_be);
             ctrl.args.splice(pos, 0, {
               type: exprType ? ctrl.exprTypesByType[exprType].name : null,
-              flag_before: _.filter(_.keys(ctrl.fn.params[pos].flag_before))[0],
-              flag_after: _.filter(_.keys(ctrl.fn.params[pos].flag_after))[0],
+              flag_before: Object.keys(ctrl.fn.params[pos].flag_before || {}).filter(Boolean)[0],
+              flag_after: Object.keys(ctrl.fn.params[pos].flag_after || {}).filter(Boolean)[0],
               name: ctrl.fn.params[pos].name,
               value: exprType === 'SqlNumber' ? 0 : ''
             });
@@ -199,8 +199,9 @@
           }
           // Update fieldArg
           const fieldParam = ctrl.fn.params[pos];
-          ctrl.fieldArg.flag_before = _.keys(fieldParam.flag_before)[0];
-          ctrl.fieldArg.flag_after = _.keys(fieldParam.flag_after)[0];
+          // Empty flag lists are stripped from the metadata server-side, so these may be absent
+          ctrl.fieldArg.flag_before = Object.keys(fieldParam.flag_before || {})[0];
+          ctrl.fieldArg.flag_after = Object.keys(fieldParam.flag_after || {})[0];
           ctrl.fieldArg.name = fieldParam.name;
           initFunction();
         }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js
@@ -16,7 +16,7 @@
       this.getWidget = function() {
         if (!ctrl.param || !ctrl.param[ctrl.flag]) {
           return null;
-        } else if (_.keys(ctrl.param[ctrl.flag]).length === 2 && '' in ctrl.param[ctrl.flag]) {
+        } else if (Object.keys(ctrl.param[ctrl.flag]).length === 2 && '' in ctrl.param[ctrl.flag]) {
           return 'checkbox';
         } else {
           return 'select';

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js
@@ -25,8 +25,8 @@
       }
       const oldNames = getColNames(display.original.settings.columns);
       const newNames = getColNames(display.updated.settings.columns);
-      const removed = _.difference(_.keys(oldNames), _.keys(newNames));
-      const changed = _.filter(_.keys(oldNames), (srcKey) =>  newNames[srcKey] && newNames[srcKey] != oldNames[srcKey]);
+      const removed = _.difference(Object.keys(oldNames), Object.keys(newNames));
+      const changed = Object.keys(oldNames).filter((srcKey) => newNames[srcKey] && newNames[srcKey] != oldNames[srcKey]);
 
       removed.forEach(function(srcKey) {
         data.messages.push(ts('In entity "%1", remove column "%2".', {1: entityLabel, 2: oldNames[srcKey]}));

--- a/js/Common.js
+++ b/js/Common.js
@@ -1111,7 +1111,7 @@ if (!CRM.vars) CRM.vars = {};
       _.defaults(filter, {type: 'select', 'attributes': {}, entity: entity});
       if (!params[filter.key]) {
         // Filter out options if params don't match its condition
-        if (filter.condition && !_.isMatch(params, _.pick(filter.condition, _.keys(params)))) {
+        if (filter.condition && !_.isMatch(params, _.pick(filter.condition, Object.keys(params)))) {
           return;
         }
         result.push(filter);

--- a/js/model/crm.schema-mapped.js
+++ b/js/model/crm.schema-mapped.js
@@ -30,7 +30,7 @@
       .ajax({
         url: CRM.url("civicrm/profile-editor/schema"),
         data: {
-          'entityTypes': _.keys(CRM.civiSchema).join(',')
+          'entityTypes': Object.keys(CRM.civiSchema).join(',')
         },
         type: 'POST',
         dataType: 'json',

--- a/js/view/crm.profile-selector.js
+++ b/js/view/crm.profile-selector.js
@@ -115,9 +115,9 @@
           CRM.api('UFGroup', 'getsingle', {id: ufID, "api.UFField.get": 1}, {
             success: function(formData) {
               // Note: With chaining, API returns some extraneous keys that aren't part of UFGroupModel
-              var ufGroupModel = new CRM.UF.UFGroupModel(_.pick(formData, _.keys(CRM.UF.UFGroupModel.prototype.schema)));
+              var ufGroupModel = new CRM.UF.UFGroupModel(_.pick(formData, Object.keys(CRM.UF.UFGroupModel.prototype.schema)));
               ufGroupModel.setUFGroupModel(ufGroupModel.calculateContactEntityType(), profileSelectorView.options.ufEntities);
-              ufGroupModel.getRel('ufFieldCollection').reset(_.values(formData["api.UFField.get"].values));
+              ufGroupModel.getRel('ufFieldCollection').reset(Object.values(formData["api.UFField.get"].values));
               options.onLoad(ufGroupModel);
             }
           });
@@ -137,9 +137,9 @@
           CRM.api('UFGroup', 'getsingle', {id: ufID, "api.UFField.get": 1}, {
             success: function(formData) {
               // Note: With chaining, API returns some extraneous keys that aren't part of UFGroupModel
-              var ufGroupModel = new CRM.UF.UFGroupModel(_.pick(formData, _.keys(CRM.UF.UFGroupModel.prototype.schema)));
+              var ufGroupModel = new CRM.UF.UFGroupModel(_.pick(formData, Object.keys(CRM.UF.UFGroupModel.prototype.schema)));
               ufGroupModel.setUFGroupModel(ufGroupModel.calculateContactEntityType(), profileSelectorView.options.ufEntities);
-              ufGroupModel.getRel('ufFieldCollection').reset(_.values(formData["api.UFField.get"].values));
+              ufGroupModel.getRel('ufFieldCollection').reset(Object.values(formData["api.UFField.get"].values));
               options.onLoad(ufGroupModel.deepCopy());
             }
           });


### PR DESCRIPTION
Overview
----------------------------------------
Continues the removal of lodash from core JS by replacing all 20 remaining `_.keys()` and `_.values()` calls with the native equivalents.

Before
----------------------------------------
20 calls across 10 files, e.g.:

```js
Attachment.files = _.values(apiResult.values);
'entityTypes': _.keys(CRM.civiSchema).join(',')
flag_before: _.filter(_.keys(param.flag_before))[0],
```

After
----------------------------------------
```js
Attachment.files = Object.values(apiResult.values);
'entityTypes': Object.keys(CRM.civiSchema).join(',')
flag_before: Object.keys(param.flag_before || {}).filter(Boolean)[0],
```

Technical Details
----------------------------------------
`_.keys(null)` and `_.values(null)` return `[]`, whereas the native methods throw, so every argument was traced to its origin — API responses, `addVars` page variables, local objects, or metadata — and checked against live data rather than against the PHP that produces it.

Two can legitimately be absent and get an explicit `|| {}`:

- `entity.fields` in `afGuiEditor.getSearchDisplayEntities()` — `afGui.resetMeta()` deletes `fields` between form loads and it is only repopulated for entities the current form uses, so a joined entity frequently has none.
- the SQL function `flag_before`/`flag_after` metadata in SearchKit — `Civi\Search\Admin::getSqlFunctions()` runs `array_filter()` over every param ("Filter out empty param properties (simplifies the javascript which treats empty arrays/objects as != null)"), so although `SqlFunction::getParams()` defaults both to `[]`, they arrive at the browser **absent** on 114 of 130 param slots. Without the guard, simply rendering the field editor for any function without flags throws.

The surrounding `_.filter()` goes native in the same expressions, since `_.filter(_.keys(x))` reads better as `Object.keys(x).filter(Boolean)`.

Files touched: `ang/crmAttachment.js`, `ext/afform/admin/ang/afGuiEditor.js`, `ext/civi_case/ang/crmCaseType.js`, `ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js`, `ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js`, `ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.component.js`, `ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js`, `js/Common.js`, `js/model/crm.schema-mapped.js`, `js/view/crm.profile-selector.js`.

Comments
----------------------------------------
Karma suite green (81/81, run 4 times). Manually exercised in a standalone sandbox: the SearchKit function editor rendering `COUNT(DISTINCT)`, `MAX`, `UPPER` and plain fields side by side — covering both `crmSearchFunctionFlag.getWidget()` branches (checkbox for a two-option flag list, select otherwise); a parity sweep comparing lodash against native across all 45 SQL functions and 130 flag slots (no mismatches, no throws); `selectFunction()` and `addArg()` driven across all 45 functions with 59 arguments added; `afGui.getSearchDisplayEntities()` with a bridged join, both with and without the joined entity's fields loaded; and `CRM.Schema.reloadModels()` plus the profile designer's `UFGroupModel` schema lookup on an event registration screen.