### PR TITLE
Replace lodash type checks and string helpers with native equivalents

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -293,7 +293,7 @@
           // Link to php classes on GitHub.
           // Fixme: Only works for files in the core repo
           if (ref[0] === '\\' || ref.indexOf('Civi\\') === 0 || ref.indexOf('CRM_') === 0) {
-            let classFunction = _.trim(ref, '\\').split('::'),
+            let classFunction = ref.replace(/^\\+|\\+$/g, '').split('::'),
               replacement = new RegExp(classFunction[0].indexOf('CRM_') === 0 ? '_' : '\\\\', 'g');
             ref = 'https://github.com/civicrm/civicrm-core/blob/master/' + classFunction[0].replace(replacement, '/') + '.php';
           }
@@ -961,7 +961,7 @@ apiCalls.${results} = [${jsCall}];
     function formatOOP(entity, action, params, indent) {
       const info = getEntity(entity),
         arrayParams = ['groupBy', 'records'],
-        newLine = "\n" + _.repeat(' ', indent),
+        newLine = "\n" + ' '.repeat(indent),
         args = structuredClone(info.class_args || []);
       let code = '\\' + info.class + '::' + action + '(';
       // Always shows implicit true permissions check for PHP
@@ -1031,7 +1031,7 @@ apiCalls.${results} = [${jsCall}];
     function formatMeta(resp) {
       let ret = '';
       _.each(resp, function(val, key) {
-        if (key !== 'values' && !_.isPlainObject(val) && !_.isFunction(val)) {
+        if (key !== 'values' && !_.isPlainObject(val) && typeof val !== 'function') {
           ret += (ret.length ? ', ' : '') + key + ': ' + (Array.isArray(val) ? '[' + val + ']' : val);
         }
       });
@@ -1116,7 +1116,7 @@ apiCalls.${results} = [${jsCall}];
         return JSON.stringify(val).toUpperCase();
       }
       let indentChild = indentChildren ? indent + indentChildren : null;
-      indent = (typeof indent === 'number') ? _.repeat(' ', indent) : (indent || '');
+      indent = (typeof indent === 'number') ? ' '.repeat(indent) : (indent || '');
       let ret = '',
         baseLine = indent ? indent.slice(0, -2) : '',
         newLine = indent ? '\n' : '',
@@ -1255,7 +1255,7 @@ apiCalls.${results} = [${jsCall}];
 
     // Update route when changing actions
     $scope.$watch('action', function(newVal, oldVal) {
-      if ($scope.entity && $routeParams.api4action !== newVal && !_.isUndefined(newVal)) {
+      if ($scope.entity && $routeParams.api4action !== newVal && newVal !== undefined) {
         $location.url('/explorer/' + $scope.entity + '/' + newVal);
       } else if (newVal) {
         setHelp($scope.entity + '::' + newVal, _.pick(getEntity().actions.find((a) => a.name === newVal), ['description', 'comment', 'see', 'deprecated']));
@@ -1516,7 +1516,7 @@ apiCalls.${results} = [${jsCall}];
 
           if (viewValue) {
             viewValue.split("\u0001").forEach((value) => {
-              if (value) list.push(_.trim(value));
+              if (value) list.push(value.trim());
             });
           }
 

--- a/ang/crmAutosave.js
+++ b/ang/crmAutosave.js
@@ -31,7 +31,7 @@
         if (saving) {
           return;
         }
-        var currentModel = _.isFunction(options.model) ? options.model() : options.model;
+        var currentModel = typeof options.model === 'function' ? options.model() : options.model;
         if (!angular.equals(currentModel, lastSeenModel)) {
           lastSeenModel = angular.copy(currentModel);
           if (jobs.save) {
@@ -47,7 +47,7 @@
           return;
         }
 
-        var form = _.isFunction(options.form) ? options.form() : options.form;
+        var form = typeof options.form === 'function' ? options.form() : options.form;
 
         if (options.saveIf) {
           if (!options.saveIf()) {
@@ -59,7 +59,7 @@
         }
 
         saving = true;
-        lastSeenModel = angular.copy(_.isFunction(options.model) ? options.model() : options.model);
+        lastSeenModel = angular.copy(typeof options.model === 'function' ? options.model() : options.model);
 
         // Set to pristine before saving -- not after saving.
         // If an eager user continues editing concurrent with the
@@ -90,7 +90,7 @@
 
       this.start = function() {
         if (!jobs.poll) {
-          lastSeenModel = angular.copy(_.isFunction(options.model) ? options.model() : options.model);
+          lastSeenModel = angular.copy(typeof options.model === 'function' ? options.model() : options.model);
           jobs.poll = $interval(checkChanges, intervals.poll);
         }
       };

--- a/ang/crmDialog.js
+++ b/ang/crmDialog.js
@@ -18,7 +18,7 @@
         $element.on('click', function() {
           var options = CRM.utils.adjustDialogDefaults({
             autoOpen: false,
-            title: _.trim($element.attr('title') || $element.text())
+            title: ($element.attr('title') || $element.text()).trim()
           });
           dialogService.open(ctrl.popupName, ctrl.popupTpl, ctrl.popupData || {}, options)
             .then(function(success) {

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -780,7 +780,7 @@
             if (viewValue) {
               _.each(viewValue.split(','), function(value) {
                 if (value) {
-                  list.push(_.trim(value));
+                  list.push(value.trim());
                 }
               });
             }

--- a/ang/crmUtil.js
+++ b/ang/crmUtil.js
@@ -84,7 +84,7 @@
       // usage: $q.when(crmMetadata.getFields(['MyEntity', 'myaction'])).then(...);
       getFields: function getFields(entity) {
         var action = '', cacheKey;
-        if (_.isArray(entity)) {
+        if (Array.isArray(entity)) {
           action = entity[1];
           entity = entity[0];
           cacheKey = entity + '::' + action;

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -14,7 +14,7 @@
           if (_.isPlainObject(item)) {
             evaluate(item['#children']);
             _.each(item, function(prop, key) {
-              if (_.isString(prop) && !_.includes(doNotEval, key)) {
+              if (typeof prop === 'string' && !_.includes(doNotEval, key)) {
                 if (looksLikeJs(prop)) {
                   try {
                     item[key] = $parse(prop)({ts: CRM.ts('afform')});
@@ -28,7 +28,7 @@
       }
 
       function looksLikeJs(str) {
-        str = _.trim(str);
+        str = str.trim();
         let firstChar = str.charAt(0);
         let lastChar = str.slice(-1);
         return (firstChar === '{' && lastChar === '}') ||
@@ -335,7 +335,7 @@
         getFormElements: function getFormElements(collection, predicate, exclude) {
           let childMatches = [];
           let items = _.filter(collection, predicate);
-          let isExcluded = exclude ? (_.isFunction(exclude) ? exclude : _.matches(exclude)) : _.constant(false);
+          let isExcluded = exclude ? (typeof exclude === 'function' ? exclude : _.matches(exclude)) : _.constant(false);
 
           function isIncluded(item) {
             return !isExcluded(item);
@@ -402,9 +402,9 @@
             return [];
           }
           // Split contents by commas, ignoring commas inside quotes
-          const rawValues = _.trim(filterString, '{}').split(/,(?=(?:(?:[^']*'){2})*[^']*$)/);
+          const rawValues = filterString.replace(/^[{}]+|[{}]+$/g, '').split(/,(?=(?:(?:[^']*'){2})*[^']*$)/);
           return rawValues.map((raw) => {
-            raw = _.trim(raw);
+            raw = raw.trim();
             let split;
             if (raw.charAt(0) === '"') {
               split = raw.slice(1).split(/"[ ]*:/);
@@ -413,8 +413,8 @@
             } else {
               split = raw.split(':');
             }
-            const key = _.trim(split[0]);
-            const value = _.trim(split[1]);
+            const key = split[0].trim();
+            const value = (split[1] || '').trim();
             let mode = 'val';
             if (value.startsWith('routeParams')) {
               mode = 'routeParams';

--- a/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiConditionalDialog.ctrl.js
@@ -62,7 +62,7 @@
       if (!ctrl.node[rule]) {
         return [];
       }
-      const raw = _.trim(ctrl.node[rule].replace(/&quot;/g, '"'));
+      const raw = ctrl.node[rule].replace(/&quot;/g, '"').trim();
       if (raw.charAt(0) !== '(') {
         return [];
       }

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -605,7 +605,7 @@
             ctrl.hasDefaultValue = false;
             if (!ctrl.isMultiSelect() && Array.isArray(getSet('afform_default'))) {
               ctrl.node.defn.afform_default = ctrl.node.defn.afform_default[0];
-            } else if (ctrl.isMultiSelect() && _.isString(getSet('afform_default')) && ctrl.node.defn.afform_default.length) {
+            } else if (ctrl.isMultiSelect() && typeof getSet('afform_default') === 'string' && ctrl.node.defn.afform_default.length) {
               ctrl.node.defn.afform_default = ctrl.node.defn.afform_default.split(',');
             }
             $timeout(() => {

--- a/ext/civi_case/ang/crmCaseType.js
+++ b/ext/civi_case/ang/crmCaseType.js
@@ -369,7 +369,7 @@
 
       _.each($scope.caseType.definition.activitySets, function (set) {
         _.each(set.activityTypes, function (type, name) {
-          var isDefaultAssigneeTypeUndefined = _.isUndefined(type.default_assignee_type);
+          var isDefaultAssigneeTypeUndefined = type.default_assignee_type === undefined;
           var typeDefinition = $scope.activityTypes[type.name];
           type.label = (typeDefinition && typeDefinition.label) || type.name;
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.component.js
@@ -41,7 +41,7 @@
             // Use singular title for main entity
             entityLabel = i ? group.text : entityLabel;
             _.transform(group.children, function(iconFields, field) {
-              if (field.id && _.endsWith(field.id, 'icon')) {
+              if (field.id && field.id.endsWith('icon')) {
                 field.text = entityLabel + ' - ' + field.text;
                 iconFields.push(field);
               }

--- a/js/Common.js
+++ b/js/Common.js
@@ -605,7 +605,7 @@ if (!CRM.vars) CRM.vars = {};
     };
 
     return _.transform(staticItems || [], function(staticItems, option) {
-      staticItems.push(_.isString(option) ? staticPresets[option] : option);
+      staticItems.push(typeof option === 'string' ? staticPresets[option] : option);
     });
   }
 

--- a/js/crm.backbone.js
+++ b/js/crm.backbone.js
@@ -13,7 +13,7 @@
    * @see tests/qunit/crm-backbone
    */
   CRM.Backbone.sync = function(method, model, options) {
-    var isCollection = _.isArray(model.models);
+    var isCollection = Array.isArray(model.models);
 
     var apiOptions, params;
     if (isCollection) {
@@ -525,7 +525,7 @@
           // probably keyed by field names... but not necessarily, so we use _others
           // as a fallback.
           if (modelErrors) {
-            var isDictionary = _.isObject(modelErrors) && !_.isArray(modelErrors);
+            var isDictionary = _.isObject(modelErrors) && !Array.isArray(modelErrors);
 
             //If errors are not in object form then just store on the error object
             if (!isDictionary) {

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -299,9 +299,9 @@
                 filters: {},
               };
             if (option.val() === 'sort_name') {
-              params.input = _.trim(request.term);
+              params.input = request.term.trim();
             } else {
-              params.filters[option.val()] = _.trim(request.term);
+              params.filters[option.val()] = request.term.trim();
             }
             // Specialized Autocomplete SearchDisplay: @see ContactAutocompleteProvider
             CRM.api4('Contact', 'autocomplete', params).then(function(result) {

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -49,7 +49,7 @@
   CRM.UF.parseTypeList = function(groupTypeExpr) {
     var typeList = {coreTypes: {}, subTypes:{}};
     // The API may have automatically converted a string with '\0' to an array
-    var parts = _.isArray(groupTypeExpr) ? groupTypeExpr : groupTypeExpr.replace(';;','\0').split('\0');
+    var parts = Array.isArray(groupTypeExpr) ? groupTypeExpr : groupTypeExpr.replace(';;','\0').split('\0');
     var coreTypesExpr = parts[0];
     var subTypesExpr = parts[1];
 
@@ -781,7 +781,7 @@
       var profileType = ufGroupModel.get('group_type') || '';
 
       // check if selected profile have subtype defined eg: ["Individual,Contact,Case", "caseType:7"]
-      if (_.isArray(profileType) && profileType[0]) {
+      if (Array.isArray(profileType) && profileType[0]) {
         profileType = profileType[0];
       }
       profileType = profileType.split(',');


### PR DESCRIPTION
Overview
----------------------------------------
Continues the removal of lodash from core JS with the calls that have nothing to do with collections: type checks and string helpers.

Before
----------------------------------------
31 calls across 14 files, e.g.:

```js
if (_.isArray(entity)) {
var form = _.isFunction(options.form) ? options.form() : options.form;
params.input = _.trim(request.term);
newLine = "\n" + _.repeat(' ', indent),
```

After
----------------------------------------
```js
if (Array.isArray(entity)) {
var form = typeof options.form === 'function' ? options.form() : options.form;
params.input = request.term.trim();
newLine = "\n" + ' '.repeat(indent),
```

Technical Details
----------------------------------------
`_.isArray()`, `_.isFunction()`, `_.isString()` and `_.isUndefined()` map onto `Array.isArray()`, `typeof` and `=== undefined`. The lodash versions also accept boxed objects (`new String()`), which nothing here produces.

Two differences needed handling.

lodash coerces a null or undefined argument to `''` where `String.prototype.trim()` throws. Every one of the twelve `_.trim()` arguments was traced: eleven are already guaranteed strings — `looksLikeJs()` is only reached under an `_.isString()` test, jQuery UI's autocomplete `request.term` is always a string, `$element.text()` backs the `||` in `crmDialog`. The exception is `afGuiEditor.parseDisplayFilters()`, where `split[1]` is undefined for a filter with no `:`, so it gets an explicit `|| ''`.

`_.trim()` also takes an optional set of characters to strip, which the native method has no equivalent for. Two sites use it — `Explorer.js` stripping backslashes from a PHP class reference, and `parseDisplayFilters()` stripping braces — and become explicit regexes. Both were checked against lodash across real and adversarial inputs (leading/trailing runs, all-delimiter strings, delimiters in the middle) with no divergence.

`_.repeat(' ', indent)` returns `''` for a negative count where `String.prototype.repeat()` throws; `formatOOP()` and `phpFormat()` only ever start at an indent of 2 or 4 and add to it.

Comments
----------------------------------------
Karma suite green (81/81, run three times after rebasing).

Two `_.capitalize()` calls are deliberately left alone. Both wrap `_.camelCase()`, which has no native equivalent, so converting only the outer call would leave a more awkward expression than it started with — they belong with whatever handles the case converters. Worth noting for that work: core bundles **lodash-compat 3.0.1**, where `_.capitalize('fooBar')` returns `'FooBar'`. It does not lowercase the remainder — that behaviour arrived in lodash 4, and assuming it would silently corrupt both call sites.