### PR TITLE
Replace lodash array set operations with native equivalents

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -990,7 +990,7 @@ apiCalls.${results} = [${jsCall}];
           // selectRowCount() is a shortcut for addSelect('row_count')
           if (isSelectRowCount(params)) {
             code += newLine + '->selectRowCount()';
-            param = _.without(param, 'row_count');
+            param = param.filter((p) => p !== 'row_count');
           }
           // addSelect() is a variadic function & can take multiple arguments
           if (param.length) {
@@ -1091,7 +1091,7 @@ apiCalls.${results} = [${jsCall}];
           let action = getEntity().actions.find((a) => a.name === $scope.action);
           let localizable = action.fields.filter((f) => f.localizable === true).map((f) => f.name) || [];
           // More field names that probably should be translated
-          localizable = _.union(localizable, ['label', 'title', 'description', 'text']);
+          localizable = [...new Set([...localizable, 'label', 'title', 'description', 'text'])];
           // SearchKit settings are not needs to be translated at runtime and not once when the managed file is loaded in the database
           const ignoreLocalization = ['settings'];
           $scope.result.push(prettyPrintOne('return ' + CRM.utils.escapeHtml(phpFormat(response.values, 2, 2, localizable, ignoreLocalization)) + ';', 'php_ts', 1));

--- a/ang/exportui/exportui.js
+++ b/ang/exportui/exportui.js
@@ -65,7 +65,7 @@
           $scope.data.columns.push(col);
         });
         // If all the fields are for the same contact type, set it form-wide
-        if (!$scope.data.contact_type && _.unique(mapContactTypes).length === 1) {
+        if (!$scope.data.contact_type && new Set(mapContactTypes).size === 1) {
           $scope.data.contact_type = mapContactTypes[0];
         }
       }

--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -103,10 +103,11 @@
       function modifyClasses(node, toRemove, toAdd) {
         let classes = splitClass(node['class']);
         if (toRemove) {
-          classes = _.difference(classes, splitClass(toRemove));
+          const removing = splitClass(toRemove);
+          classes = classes.filter((c) => !removing.includes(c));
         }
         if (toAdd) {
-          classes = _.unique(classes.concat(splitClass(toAdd)));
+          classes = [...new Set(classes.concat(splitClass(toAdd)))];
         }
         if (classes.length) {
           node['class'] = classes.join(' ');

--- a/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemStyle.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiMenuItemStyle.component.js
@@ -19,7 +19,7 @@
         if (arguments.length) {
           afGui.modifyClasses(ctrl.node, options, style);
         }
-        return _.intersection(afGui.splitClass(ctrl.node['class']), options)[0] || '';
+        return afGui.splitClass(ctrl.node['class']).find((c) => options.includes(c)) || '';
       };
 
     }

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.component.js
@@ -30,7 +30,7 @@
         if (arguments.length) {
           return afGui.modifyClasses(ctrl.node, Object.keys($scope.styles), ['btn', val]);
         }
-        return _.intersection(afGui.splitClass(ctrl.node['class']), Object.keys($scope.styles))[0] || '';
+        return afGui.splitClass(ctrl.node['class']).find((c) => c in $scope.styles) || '';
       };
 
       $scope.pickIcon = () => {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -527,7 +527,7 @@
             ctrl.node.defn.afform_default = [];
           }
           if (_.includes(ctrl.node.defn.afform_default, val)) {
-            const newVal = _.without(ctrl.node.defn.afform_default, val);
+            const newVal = ctrl.node.defn.afform_default.filter((v) => v !== val);
             getSet('afform_default', newVal.length ? newVal : undefined);
             ctrl.hasDefaultValue = !!newVal.length;
           } else {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiText.component.js
@@ -34,7 +34,7 @@
       };
 
       $scope.getAlign = function() {
-        return _.intersection(afGui.splitClass(ctrl.node['class']), Object.keys($scope.alignments))[0] || 'text-left';
+        return afGui.splitClass(ctrl.node['class']).find((c) => c in $scope.alignments) || 'text-left';
       };
 
       $scope.setAlign = function(val) {
@@ -50,7 +50,7 @@
         if (arguments.length) {
           return afGui.modifyClasses(ctrl.node, Object.keys($scope.styles), val === 'text-default' ? null : val);
         }
-        return _.intersection(afGui.splitClass(ctrl.node['class']), Object.keys($scope.styles))[0] || 'text-default';
+        return afGui.splitClass(ctrl.node['class']).find((c) => c in $scope.styles) || 'text-default';
       };
 
     }

--- a/ext/civi_mail/ang/crmMailing/EditUnsubGroupCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EditUnsubGroupCtrl.js
@@ -13,7 +13,7 @@
             mandatoryIds.push(parseInt(grp.id));
           }
         });
-        return _.intersection(mandatoryIds, mailing.recipients.groups.include).length > 0;
+        return mandatoryIds.some((id) => mailing.recipients.groups.include.includes(id));
       }
     };
   });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -188,7 +188,7 @@
           }
         });
 
-        field.label = _.uniq(setLabels).join(' / ');
+        field.label = [...new Set(setLabels)].join(' / ');
         return field;
       });
     };

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.component.js
@@ -43,7 +43,7 @@
           }
         }
         // Ensure array is unique
-        ctrl.display.settings.searchFields = _.uniq(ctrl.display.settings.searchFields);
+        ctrl.display.settings.searchFields = [...new Set(ctrl.display.settings.searchFields)];
       };
 
     }

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js
@@ -25,7 +25,7 @@
       }
       const oldNames = getColNames(display.original.settings.columns);
       const newNames = getColNames(display.updated.settings.columns);
-      const removed = _.difference(Object.keys(oldNames), Object.keys(newNames));
+      const removed = Object.keys(oldNames).filter((srcKey) => !(srcKey in newNames));
       const changed = Object.keys(oldNames).filter((srcKey) => newNames[srcKey] && newNames[srcKey] != oldNames[srcKey]);
 
       removed.forEach(function(srcKey) {

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -354,7 +354,7 @@
         }).then(function(afforms) {
           ctrl.afforms = {};
           _.each(afforms, function(afform) {
-            _.each(_.uniq(afform.search_displays), function(searchNameDisplayName) {
+            _.each([...new Set(afform.search_displays)], function(searchNameDisplayName) {
               const searchName = searchNameDisplayName.split('.')[0];
               ctrl.afforms[searchName] = ctrl.afforms[searchName] || [];
               ctrl.afforms[searchName].push({

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -119,7 +119,7 @@
       // Select all rows on the current page
       selectPage: function() {
         this.allRowsSelected = (this.rowCount <= this.results.length);
-        this.selectedRows = _.uniq(this.results.map((result) => result.key));
+        this.selectedRows = [...new Set(this.results.map((result) => result.key))];
       },
 
       // Clear selection
@@ -184,7 +184,7 @@
               selectRange(allRows, nearestBefore + 1, checkboxPosition -1);
             }
           }
-          ctrl.selectedRows = _.uniq(ctrl.selectedRows.concat([row.key]));
+          ctrl.selectedRows = [...new Set(ctrl.selectedRows.concat([row.key]))];
           ctrl.allRowsSelected = (ctrl.rowCount === ctrl.selectedRows.length);
         } else {
           ctrl.allRowsSelected = false;

--- a/js/Common.js
+++ b/js/Common.js
@@ -749,7 +749,8 @@ if (!CRM.vars) CRM.vars = {};
           if (val === '') {
             return;
           }
-          var idsNeeded = _.difference(val.split(','), staticItems.map((item) => item.id)),
+          var staticIds = staticItems.map((item) => item.id),
+            idsNeeded = val.split(',').filter((id) => !staticIds.includes(id)),
             existing = _.filter(staticItems, function(item) {
               return _.includes(val.split(','), item.id);
             });
@@ -895,7 +896,8 @@ if (!CRM.vars) CRM.vars = {};
           if (val === '') {
             return;
           }
-          var idsNeeded = _.difference(val.split(','), stored.map((item) => item.id));
+          var storedIds = stored.map((item) => item.id);
+          var idsNeeded = val.split(',').filter((id) => !storedIds.includes(id));
           var existing = _.remove(stored, function(item) {
             return _.includes(val.split(','), item.id);
           });

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -750,19 +750,20 @@
       // FIXME: hide/display 'in_selector' if 'visibility' is one of the public options
       var fields = ['location_type_id', 'website_type_id', 'phone_type_id', 'label', 'is_multi_summary', 'is_required', 'is_view', 'visibility', 'in_selector', 'is_searchable', 'help_pre', 'help_post', 'is_active'];
       if (! this.options.fieldSchema.civiIsLocation) {
-        fields = _.without(fields, 'location_type_id');
+        fields = fields.filter((f) => f !== 'location_type_id');
       }
       if (! this.options.fieldSchema.civiIsWebsite) {
-        fields = _.without(fields, 'website_type_id');
+        fields = fields.filter((f) => f !== 'website_type_id');
       }
       if (! this.options.fieldSchema.civiIsPhone) {
-        fields = _.without(fields, 'phone_type_id');
+        fields = fields.filter((f) => f !== 'phone_type_id');
       }
       if (!this.options.fieldSchema.civiIsMultiple) {
-        fields = _.without(fields, 'is_multi_summary');
+        fields = fields.filter((f) => f !== 'is_multi_summary');
       }
       if (this.options.fieldSchema.type == 'Markup') {
-        fields = _.without(fields, 'is_required', 'is_view', 'visibility', 'in_selector', 'is_searchable', 'help_post');
+        var markupExcluded = ['is_required', 'is_view', 'visibility', 'in_selector', 'is_searchable', 'help_post'];
+        fields = fields.filter((f) => !markupExcluded.includes(f));
       }
 
       this.form = new Backbone.Form({


### PR DESCRIPTION
Overview
  ----------------------------------------
matching the surrounding idiom is the wrong instinct here. (Flagged by a reviewer on civicrm-core PR #36794: "I usually add 'prefer arrow functions' to my pro
mpt because there's a lot of overly-verbose `( function(x) { return x... } )` in here.") Likewise prefer `!arr.includes(x)` over `arr.indexOf(x) < 0`, and `k in obj` ov
er `Object.keys(obj).includes(k)`.
- PR descriptions for civicrm-core must use this template (sections in this order; omit the italic prompt text, keep the section headers):

  ```


Overview
----------------------------------------
Continues the removal of lodash from core JS by replacing the array set operations.

Before
----------------------------------------
24 calls across 15 files, e.g.:

```js
classes = _.difference(classes, splitClass(toRemove));
classes = _.unique(classes.concat(splitClass(toAdd)));
const removed = _.difference(Object.keys(oldNames), Object.keys(newNames));
return _.intersection(afGui.splitClass(ctrl.node['class']), Object.keys($scope.styles))[0] || '';
fields = _.without(fields, 'is_required', 'is_view', 'visibility', 'in_selector', 'is_searchable', 'help_post');
```

After
----------------------------------------
```js
const removing = splitClass(toRemove);
classes = classes.filter((c) => !removing.includes(c));
classes = [...new Set(classes.concat(splitClass(toAdd)))];
const removed = Object.keys(oldNames).filter((srcKey) => !(srcKey in newNames));
return afGui.splitClass(ctrl.node['class']).find((c) => c in $scope.styles) || '';
var markupExcluded = ['is_required', 'is_view', 'visibility', 'in_selector', 'is_searchable', 'help_post'];
fields = fields.filter((f) => !markupExcluded.includes(f));
```

Technical Details
----------------------------------------
`_.without()`, `_.difference()` and `_.intersection()` become `filter()` with `includes()`; `_.uniq()`/`_.unique()` become a `Set`. Every argument was checked to be a real array, since lodash treats a null or undefined collection as empty where the native methods throw — `mailing.recipients.groups.include`, the least obvious of them, is initialised to `[]` in two places in `crmMailing`'s services.

Where the lodash call was really asking a different question, the native version now says so. `_.intersection(a, b)[0]` is "the first member of a that is also in b", so those four sites read as `a.find(...)`, and the one testing `.length > 0` becomes `a.some(...)`. Three of them were testing membership of `Object.keys(obj)`, which is just `c in obj`.

`_.without()` is variadic, so the site excluding six field names at once gets a named list rather than six chained comparisons.

Comments
----------------------------------------
Karma suite green (81/81, run three times after rebasing).

One call is deliberately left behind: `searchDisplayTasksTrait.service.js:115` wraps a `_.toArray()` that belongs with the positional-access conversions in #36795.

A second, `EditRecipCtrl.js:53`, is a pre-existing bug rather than a conversion, so it is better fixed on its own terms than quietly rewritten here. It compares the result of `_.difference()` to `0`, which an array is never equal to, and it passes `mailing.recipients` — an object, not an array — as the first argument, so lodash returns an empty array regardless of the contents. The expression is therefore always true, and `$scope.outdated` is set purely by `permitRecipientRebuild`. Happy to open a separate PR for it if you agree with that reading.
  Continues the removal of lodash from core JS by replacing the array set operations.

  Before
  ----------------------------------------
  24 calls across 15 files, e.g.:

  ```js
  classes = _.difference(classes, splitClass(toRemove));
  classes = _.unique(classes.concat(splitClass(toAdd)));
  const removed = _.difference(Object.keys(oldNames), Object.keys(newNames));
  return _.intersection(afGui.splitClass(ctrl.node['class']), Object.keys($scope.styles))[0] || '';
  fields = _.without(fields, 'is_required', 'is_view', 'visibility', 'in_selector', 'is_searchable', 'help_post');
  ```

  After
  ----------------------------------------
  ```js
  const removing = splitClass(toRemove);
  classes = classes.filter((c) => !removing.includes(c));
  classes = [...new Set(classes.concat(splitClass(toAdd)))];
  const removed = Object.keys(oldNames).filter((srcKey) => !(srcKey in newNames));
  return afGui.splitClass(ctrl.node['class']).find((c) => c in $scope.styles) || '';
  var markupExcluded = ['is_required', 'is_view', 'visibility', 'in_selector', 'is_searchable', 'help_post'];
  fields = fields.filter((f) => !markupExcluded.includes(f));
  ```

  Technical Details
  ----------------------------------------
  `_.without()`, `_.difference()` and `_.intersection()` become `filter()` with `includes()`; `_.uniq()`/`_.unique()` become a `Set`. Every argument was checked to be a real array, since lodash treats a null or undefined collection as empty where the native methods throw — `mailing.recipients.groups.include`, the least obvious of them, is initialised to `[]` in two places in `crmMailing`'s services.

  Where the lodash call was really asking a different question, the native version now says so. `_.intersection(a, b)[0]` is "the first member of a that is also in b", so those four sites read as `a.find(...)`, and the one testing `.length > 0` becomes `a.some(...)`. Three of them were testing membership of `Object.keys(obj)`, which is just `c in obj`.

  `_.without()` is variadic, so the site excluding six field names at once gets a named list rather than six chained comparisons.

  Comments
  ----------------------------------------
  Karma suite green (81/81, run three times after rebasing).

  One call is deliberately left behind: `searchDisplayTasksTrait.service.js:115` wraps a `_.toArray()` that belongs with the positional-access conversions in #36795.

  A second, `EditRecipCtrl.js:53`, is a pre-existing bug rather than a conversion, so it is better fixed on its own terms than quietly rewritten here. It compares the result of `_.difference()` to `0`, which an array is never equal to, and it passes `mailing.recipients` — an object, not an array — as the first argument, so lodash returns an empty array regardless of the contents. The expression is therefore always true, and `$scope.outdated` is set purely by `permitRecipientRebuild`. Happy to open a separate PR for it if you agree with that reading.