### PR TITLE
Replace lodash positional array helpers with native equivalents

### DIFF
--- a/ang/crmAttachment.js
+++ b/ang/crmAttachment.js
@@ -113,7 +113,7 @@
       deleteFile: function deleteFile(file) {
         var crmAttachments = this;
 
-        var idx = _.indexOf(this.files, file);
+        var idx = this.files.indexOf(file);
         if (idx != -1) {
           this.files.splice(idx, 1);
         }
@@ -129,7 +129,7 @@
               CRM.alert(msg, ts('Deletion failed'));
               crmAttachments.files.push(file);
 
-              var trashIdx = _.indexOf(crmAttachments.trash, file);
+              var trashIdx = crmAttachments.trash.indexOf(file);
               if (trashIdx != -1) {
                 crmAttachments.trash.splice(trashIdx, 1);
               }

--- a/ext/civi_case/ang/crmCaseType.js
+++ b/ext/civi_case/ang/crmCaseType.js
@@ -597,7 +597,7 @@
     };
 
     $scope.removeItem = function(array, item) {
-      var idx = _.indexOf(array, item);
+      var idx = array.indexOf(item);
       if (idx != -1) {
         array.splice(idx, 1);
         resetTimelineActivityTypes();
@@ -671,7 +671,7 @@
         if (v) selectedStatuses.push(k);
       });
       // Ignore if ALL or NONE selected
-      $scope.caseType.definition.statuses = selectedStatuses.length == _.size($scope.selectedStatuses) ? [] : selectedStatuses;
+      $scope.caseType.definition.statuses = selectedStatuses.length == Object.keys($scope.selectedStatuses).length ? [] : selectedStatuses;
 
       if ($scope.caseType.definition.activityAsgmtGrps) {
         $scope.caseType.definition.activityAsgmtGrps = $scope.caseType.definition.activityAsgmtGrps.toString().split(",");

--- a/ext/civi_mail/ang/crmMailing/EditMailingCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EditMailingCtrl.js
@@ -19,7 +19,7 @@
     $scope.mailingEditorUrl = templateTypes[0].editorUrl;
 
     $scope.isSubmitted = function isSubmitted() {
-      return _.size($scope.mailing.jobs) > 0;
+      return Object.keys($scope.mailing.jobs || {}).length > 0;
     };
 
     // usage: approve('Approved')

--- a/ext/civi_mail/ang/crmMailingAB/EditCtrl.js
+++ b/ext/civi_mail/ang/crmMailingAB/EditCtrl.js
@@ -12,7 +12,7 @@
     $scope.mailingFields = mailingFields;
 
     $scope.isSubmitted = function isSubmitted() {
-      return _.size(abtest.mailings.a.jobs) > 0 || _.size(abtest.mailings.b.jobs) > 0;
+      return Object.keys(abtest.mailings.a.jobs || {}).length > 0 || Object.keys(abtest.mailings.b.jobs || {}).length > 0;
     };
 
     $scope.sync = function sync() {

--- a/ext/message_admin/ang/crmMsgadm/Workflow.js
+++ b/ext/message_admin/ang/crmMsgadm/Workflow.js
@@ -7,7 +7,7 @@
         controller: 'MsgtpluiListCtrl',
         controllerAs: '$ctrl',
         templateUrl: function() {
-          var supportsTranslation = CRM.crmMsgadm.allLanguages && _.size(CRM.crmMsgadm.allLanguages) > 1;
+          var supportsTranslation = CRM.crmMsgadm.allLanguages && Object.keys(CRM.crmMsgadm.allLanguages).length > 1;
           return supportsTranslation ? '~/crmMsgadm/WorkflowTranslated.html' : '~/crmMsgadm/Workflow.html';
         },
         resolve: {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -378,7 +378,7 @@
         newEntity = 'EntitySet';
         newParams = {
           version: 4,
-          select: params.select.map((field) => _.last(field.split(' AS '))),
+          select: params.select.map((field) => field.split(' AS ').at(-1)),
           sets: [['UNION ALL', entity, 'get', params]],
         };
       }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminEntitySetSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminEntitySetSelect.component.js
@@ -101,7 +101,7 @@
               set[3].select.splice(nullIndex, 1);
             });
           });
-          this.apiParams.select = this.apiParams.sets[0][3].select.map((field) => _.last(field.split(' AS ')));
+          this.apiParams.select = this.apiParams.sets[0][3].select.map((field) => field.split(' AS ').at(-1));
         }
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -102,7 +102,7 @@
 
       this.getParam = function(index) {
         if (ctrl.fn) {
-          return ctrl.fn.params[index] || _.last(ctrl.fn.params);
+          return ctrl.fn.params[index] || ctrl.fn.params.at(-1);
         }
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.component.js
@@ -66,7 +66,7 @@
       };
 
       this.showMore = function() {
-        return !this.item.cssRules || !this.item.cssRules.length || _.last(this.item.cssRules)[1];
+        return !this.item.cssRules || !this.item.cssRules.length || this.item.cssRules.at(-1)[1];
       };
 
     }

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -112,7 +112,7 @@
         const params = ctrl.getApiParams('id');
         crmApi4('SearchDisplay', 'run', params).then(function(ids) {
           ctrl.loadingAllRows = false;
-          ctrl.selectedRows = _.uniq(_.toArray(ids));
+          ctrl.selectedRows = [...new Set(ids)];
         });
       },
 
@@ -178,9 +178,9 @@
             // Select range between clicked box and the previous/next checked box
             // In the ambiguous situation where there are checked boxes both above AND below the clicked box,
             // choose the direction of the box which was most recently clicked.
-            if (nearestAfter !== undefined && (nearestBefore === undefined || nearestAfter === allRows.indexOf(_.last(ctrl.selectedRows)))) {
+            if (nearestAfter !== undefined && (nearestBefore === undefined || nearestAfter === allRows.indexOf(ctrl.selectedRows.at(-1)))) {
               selectRange(allRows, checkboxPosition + 1, nearestAfter - 1);
-            } else if (nearestBefore !== undefined && (nearestAfter === undefined || nearestBefore === allRows.indexOf(_.last(ctrl.selectedRows)))) {
+            } else if (nearestBefore !== undefined && (nearestAfter === undefined || nearestBefore === allRows.indexOf(ctrl.selectedRows.at(-1)))) {
               selectRange(allRows, nearestBefore + 1, checkboxPosition -1);
             }
           }

--- a/js/Common.js
+++ b/js/Common.js
@@ -1020,7 +1020,7 @@ if (!CRM.vars) CRM.vars = {};
       filter = $.extend({}, $el.data('user-filter') || {});
     if (filter.key && filter.value) {
       // Fieldname may be prefixed with joins
-      var fieldName = _.last(filter.key.split('.'));
+      var fieldName = filter.key.split('.').at(-1);
       // Special case for contact type/sub-type combo
       if (fieldName === 'contact_type' && (filter.value.indexOf('__') > 0)) {
         combined.params[filter.key] = filter.value.split('__')[0];
@@ -1159,7 +1159,7 @@ if (!CRM.vars) CRM.vars = {};
         attrs += ' ' + attr + '="' + val + '"';
       });
       if (filterSpec.type === 'select') {
-        var fieldName = _.last(filter.key.split('.')),
+        var fieldName = filter.key.split('.').at(-1),
           options = [{key: '', value: ts('- select -')}];
         if (filterSpec.options) {
           options = options.concat(getEntityRefFilterOptions(fieldName, $el, filterSpec));
@@ -1198,7 +1198,7 @@ if (!CRM.vars) CRM.vars = {};
    */
   function loadEntityRefFilterOptions(filter, filterSpec, $valField, $el) {
     // Fieldname may be prefixed with joins - strip those out
-    var fieldName = _.last(filter.key.split('.'));
+    var fieldName = filter.key.split('.').at(-1);
     if (filterSpec.options) {
       CRM.utils.setOptions($valField, getEntityRefFilterOptions(fieldName, $el, filterSpec), false, filter.value);
       return;

--- a/js/crm.backbone.js
+++ b/js/crm.backbone.js
@@ -20,7 +20,7 @@
       apiOptions = {
         success: function(data) {
           // unwrap data
-          options.success(_.toArray(data.values));
+          options.success(Object.values(data.values));
         },
         error: function(data) {
           // CRM.api displays errors by default, but Backbone.sync
@@ -50,7 +50,7 @@
       apiOptions = {
         success: function(data) {
           // unwrap data
-          var values = _.toArray(data.values);
+          var values = Object.values(data.values);
           if (data.count == 1) {
             options.success(values[0]);
           } else {


### PR DESCRIPTION
Overview
----------------------------------------
Continues the removal of lodash from core JS by replacing the helpers that pick an element out of an array, count a collection, or turn one into an array.

Before
----------------------------------------
21 calls across 12 files, e.g.:

```js
var fieldName = _.last(filter.key.split('.'));
var idx = _.indexOf(this.files, file);
return _.size($scope.mailing.jobs) > 0;
options.success(_.toArray(data.values));
ctrl.selectedRows = _.uniq(_.toArray(ids));
```

After
----------------------------------------
```js
var fieldName = filter.key.split('.').at(-1);
var idx = this.files.indexOf(file);
return Object.keys($scope.mailing.jobs || {}).length > 0;
options.success(Object.values(data.values));
ctrl.selectedRows = [...new Set(ids)];
```

Technical Details
----------------------------------------
`_.last()` becomes `Array.prototype.at(-1)`, already used in three search_kit files, and `_.indexOf()` becomes the array method of the same name. Both return the same thing as lodash for an empty array.

`_.size()` and `_.toArray()` are the two that needed checking, since lodash accepts a plain object where the array methods do not. All five `_.size()` arguments turned out to be objects — `selectedStatuses` keyed by status name, `mailing.jobs` keyed by job id, `allLanguages` keyed by locale — so they become `Object.keys(…).length`, with `|| {}` on the two mailing sites, where the jobs may not have been loaded onto the mailing yet.

The `_.toArray()` calls in `CRM.Backbone.sync()` unwrap an APIv3 `values` object keyed by id, so they become `Object.values()`. Nothing in core actually reaches them: no file outside `crm.backbone.js` itself and the QUnit suite references `extendModel`, `extendCollection` or `crmEntityName`, so the sync layer is currently only of use to extensions.

The last one is `searchDisplayTasksTrait.selectAllPages()`, where `_.uniq(_.toArray(ids))` collapses to a `Set`. `SearchDisplay.run` in `id` mode indexes its result by the id field alone, which APIv4 returns as a flat list of scalars — confirmed by running select-all-pages on a live display and reading back `selectedRows`, rather than inferred from `Run.php`.

Comments
----------------------------------------
Karma suite green (81/81, run three times after rebasing). Select-all-pages exercised on a running search display: 8 rows, ids returned as a flat array of integers, all selected.

Three calls are held back. `_.first()` in `crmSearchFunction.selectFunction()` sits on the line directly below one that #36780 changes, so converting it here would conflict. `_.head()` in `crmMsgadm/ListCtrl.js` and `_.toArray()` in `afGuiEditor.component.js` share their lines with `_.filter()` calls that use lodash shorthand predicates, so they belong with that conversion rather than this one.

`tests/qunit/crm-backbone/test.js` has one `_.indexOf()` that is not converted here: the file already produces 76 jshint warnings for undefined globals, and touching it would attribute all of them to this PR's civilint run for no benefit, since that suite is not currently runnable.