### PR TITLE
Use temporary instance of BAO_Order rather than deprecated function during form validation

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -718,17 +718,22 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
-   * Is this submission incurring no cost.
+   * This is a throw-away object to calculate values, to allow it to validate
+   * input values during submission.
    *
    * @param array $fields
    *   Submitted values.
    *
-   * @return bool
+   * @return \CRM_Financial_BAO_Order
    * @throws \CRM_Core_Exception
    */
-  protected function isAmountZero(array $fields): bool {
-    $this->resetOrder($fields);
-    return empty($this->getOrder()->getTotalAmount());
+  protected function getOrderForValidatingInput(array $fields): CRM_Financial_BAO_Order {
+    $order = new CRM_Financial_BAO_Order();
+    $order->setPriceSetID($this->getPriceSetID());
+    $order->setIsExcludeExpiredFields(TRUE);
+    $order->setForm($this);
+    $order->setPriceSelectionFromUnfilteredInput($fields);
+    return $order;
   }
 
   /**

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -574,8 +574,7 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
 
     $validatePayement = FALSE;
     if (!empty($fields['priceSetId'])) {
-      $lineItem = [];
-      CRM_Price_BAO_PriceSet::processAmount($self->_values['fee'], $fields, $lineItem);
+      $fields['amount'] = $self->getOrderForValidatingInput($fields)->getTotalAmount();
       if ($fields['amount'] > 0) {
         $validatePayement = TRUE;
         // return false;

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -566,9 +566,10 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
     // whenever it's true - reset once and share the total between both
     // blocks below rather than recomputing it.
     $amount = 0.0;
+    $order = NULL;
     if (!empty($fields['priceSetId'])) {
-      $form->resetOrder($fields);
-      $amount = $form->getOrder()->getTotalAmount();
+      $order = $form->getOrderForValidatingInput($fields);
+      $amount = $order->getTotalAmount();
     }
 
     if (!empty($fields['priceSetId']) &&
@@ -595,7 +596,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         $errors['_qf_default'] = ts("Only %1 Registrations available.", [1 => $spacesAvailable]);
       }
 
-      $minAmount = $form->getOrder()->getPriceSetMetadata()['min_amount'];
+      $minAmount = $order->getPriceSetMetadata()['min_amount'];
       if ($amount < 0) {
         $errors['_qf_default'] = ts('Event Fee(s) can not be less than zero. Please select the options accordingly');
       }
@@ -614,7 +615,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         }
       }
 
-      if ($form->isAmountZero($fields)) {
+      if (empty($amount)) {
         return empty($errors) ? TRUE : $errors;
       }
 


### PR DESCRIPTION


Overview
----------------------------------------
Use temporary instance of BAO_Order rather than deprecated function during form validation

I was going down the track of using the class instance of the order object but that got endlessly complex because we want to build up the order across participants & that seems to require us to know which are submitted and which are not - which makes it hard to share that logic with this unsubmitted context.

The effect of the change made here is pretty much to copy what the legacy function was doing back into this class.

