### PR TITLE
Riverlea: darkmode tab fixes and crm-c-container-bg/crm-c-paper contrast

### DIFF
--- a/ext/riverlea/core/css/_dark.css
+++ b/ext/riverlea/core/css/_dark.css
@@ -3,10 +3,11 @@
 /* Practical colours, e.g. text, link '--crm-c-' */
   --crm-text-color: var(--crm-text-light-color);
   --crm-border-color: var(--crm-c-gray-500);
-  --crm-paper: var(--crm-c-gray-900); /* The darkest bg in dark mode */
+  --crm-paper: #202020; /* The darkest bg in dark mode */
   --crm-ink: var(--crm-text-light-color); /* The lightest foreground in dark mode */
 /* Backgrounds, '--crm-c-X-bg' */
   --crm-code-bg-color: var(--crm-layer1-bg-color);
+  --crm-container-bg-color: var(--crm-c-gray-900);
   --crm-layer1-bg-color: var(--crm-c-gray-800);
   --crm-layer2-bg-color: var(--crm-c-gray-700);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */

--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -19,7 +19,6 @@
   --crm-link-hover-color: #f2d465;
   --crm-focus-color: #00a3a5;
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-container-bg-color: var(--crm-paper);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
   --crm-primary-color: var(--crm-container-bg-color);
   --crm-primary-text-color: var(--crm-text-color);
@@ -46,7 +45,6 @@
   --crm-input-border-color: var(--crm-c-gray-500);
   --crm-form-checkbox-list-bg-color: #665800;
 /* Tabs '--crm-tabs' */
-  --crm-tab-bg-active: var(--crm-layer1-bg-color);
 /* Contact layout '--crm-contact-' */
   --crm-contact-header-bg-color: transparent;
   --crm-contact-tab-hover-bg-color: var(--crm-layer1-bg-color);

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -14,7 +14,6 @@
   --crm-link-color: var(--crm-c-teal);
   --crm-link-hover-color: var(--crm-c-yellow);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-container-bg-color: var(--crm-c-gray-800);
   --crm-inverse-bg-color: var(--crm-c-gray-300);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
   --crm-primary-color: var(--crm-c-gray-500);

--- a/ext/riverlea/streams/walbrook/_dark.css
+++ b/ext/riverlea/streams/walbrook/_dark.css
@@ -41,7 +41,8 @@
 /* Form '--crm-form-' '--crm-input-' */
   --crm-form-block-bg-color: var(--crm-container-bg-color);
   --crm-input-border-color: var(--crm-c-gray-500);
-/* Tabs '--crm-tabs'/
+/* Tabs '--crm-tabs' */
+  --crm-tab-bg-color: transparent;
 /* Contact layout '--crm-contact-' */
   --crm-contact-header-bg-color: var(--crm-layer2-bg-color);
   --crm-contact-block-bg-color: var(--crm-container-bg-color);


### PR DESCRIPTION
Overview
----------------------------------------
An alternative PR for the issue flagged in https://github.com/civicrm/civicrm-core/pull/36762 by @mattwire which addresses two additional related problems:

Before
----------------------------------------
- In Minetta and Hackney darkmodes the active tab state colour isn't different from the rest of the tabs
<img width="968" height="99" alt="image" src="https://github.com/user-attachments/assets/aa2270f5-9895-4d85-973d-6a6e6fba4e1a" />
<img width="967" height="101" alt="image" src="https://github.com/user-attachments/assets/69563fb2-b795-46f0-a468-9d83409736d5" />

- In Walbrook darkmode regular inactive tabs have a background colour, in light mode they don't
<img width="2002" height="224" alt="image" src="https://github.com/user-attachments/assets/d03d60d3-7bdb-45ca-9938-55240695aded" />

- Dark mode defaults are one shade short (tldr: in Minetta `--crm-container-bg` had the same colour as `--crm-layer1-bg`
```
  --crm-paper: var(--crm-c-container-900); /* The darkest bg in dark mode which in Hackney is #2f2f2e and Minetta #363636 */
 ```

After
----------------------------------------
- The active tab state is distinct in Minetta and Hackney. Thames is unaffected.
<img width="961" height="83" alt="image" src="https://github.com/user-attachments/assets/b29ab288-4b16-46ec-9e73-a6a3f45227d8" />
<img width="964" height="85" alt="image" src="https://github.com/user-attachments/assets/94b80825-8759-410d-8e24-b4a45707aafb" />

- Wallbrook darkmode tabs reflect the pattern in light mode
<img width="2012" height="258" alt="image" src="https://github.com/user-attachments/assets/d98bf01c-d04f-445e-887f-0ec452789ab9" />

- The `--crm-paper` color variable is now darker (`#202020), which allows the next lightest shade (`--crm-c-grey-900`) to be used by `--crm-container-bg` and making it distinct from `--crm-layer1-bg` (which uses `--crm-c-grey-800`).
```
  --crm-paper: #202020; /* The darkest bg in dark mode */
 ```

Technical Details
----------------------------------------
There is a broader change here that the default 'darkest bg' variable used for the page background and other places is now a bit darker. It's barely noticeable in Hackney, overwritten in Thames, but Minetta DarkMode users might want to look to double check the tone is ok.