### PR TITLE
prevent error on SqlCache race condition

### DIFF
--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -137,7 +137,7 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
       CRM_Core_DAO::executeQuery($sql, $args, TRUE, NULL, FALSE, FALSE);
     }
     else {
-      $sql = "INSERT INTO {$this->table} (group_name,path,data,created_date,expired_date) VALUES (%1,%2,%3,FROM_UNIXTIME(%4),FROM_UNIXTIME(%5))";
+      $sql = "INSERT IGNORE INTO {$this->table} (group_name,path,data,created_date,expired_date) VALUES (%1,%2,%3,FROM_UNIXTIME(%4),FROM_UNIXTIME(%5))";
       $args = [
         1 => [(string) $this->group, 'String'],
         2 => [$key, 'String'],


### PR DESCRIPTION
Overview
----------------------------------------
I saw an event registration crash today because of a duplicate cache entry:

```
DB Error: already exists INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VALUES ('metadata/6.18.0','CRM_Core_EntityTokenstoken_metadataContact1_en_US','YToyMDg...',FROM_UNIXTIME(1789050300),FROM_UNIXTIME(1789071901)) [nativecode=1062 ** Duplicate entry 'metadata/6.18.0-CRM_Core_EntityTokenstoken_metadataContact1_e...' for key 'UI_group_name_path']
```

I don't think this could've happened except with a race condition because we check the cache for this data before writing it - but given that this is a cache entry, I thought it safe to do `INSERT IGNORE` instead of crashing when the entry already exists. 


Technical Details
----------------------------------------
I considered `ON DUPLICATE UPDATE` but I can't think of a scenario where this value would be different so I figured we would save the write.  But it should be fine either way.

Comments
----------------------------------------
The backtrace:

```
#0 /var/www/mysite/web/sites/all/modules/civicrm/vendor/pear/db/DB.php(1000): PEAR_Error->__construct("DB Error: already exists", -5, 16, (Array:2), "INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...")
#1 /var/www/mysite/web/sites/all/modules/civicrm/vendor/pear/pear-core-minimal/src/PEAR.php(575): DB_Error->__construct(-5, 16, (Array:2), "INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...")
#2 /var/www/mysite/web/sites/all/modules/civicrm/vendor/pear/pear-core-minimal/src/PEAR.php(223): PEAR::_raiseError(Object(DB_mysqli), NULL, -5, 16, (Array:2), "INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...", "DB_Error", TRUE)
#3 /var/www/mysite/web/sites/all/modules/civicrm/vendor/pear/db/DB/common.php(1950): PEAR->__call("raiseError", (Array:7))
#4 /var/www/mysite/web/sites/all/modules/civicrm/vendor/pear/db/DB/mysqli.php(991): DB_common->raiseError(-5, NULL, NULL, "INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...", "1062 ** Duplicate entry 'metadata/6.18.0-CRM_Core_EntityTokenstoken_metadataC...")
#5 /var/www/mysite/web/sites/all/modules/civicrm/vendor/pear/db/DB/mysqli.php(440): DB_mysqli->mysqliRaiseError()
#6 /var/www/mysite/web/sites/all/modules/civicrm/vendor/pear/db/DB/common.php(1240): DB_mysqli->simpleQuery("INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...")
#7 /var/www/mysite/web/sites/all/modules/civicrm/packages/DB/DataObject.php(2696): DB_common->query("INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...")
#8 /var/www/mysite/web/sites/all/modules/civicrm/packages/DB/DataObject.php(1829): DB_DataObject->_query("INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...")
#9 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Core/DAO.php(599): DB_DataObject->query("INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...")
#10 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Core/DAO.php(1742): CRM_Core_DAO->query("INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...", FALSE)
#11 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Utils/Cache/SqlGroup.php(148): CRM_Core_DAO::executeQuery("INSERT INTO civicrm_cache (group_name,path,data,created_date,expired_date) VA...", (Array:5), TRUE, NULL, FALSE, FALSE)
#12 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Utils/Cache/CacheWrapper.php(55): CRM_Utils_Cache_SqlGroup->set("CRM_Core_EntityTokenstoken_metadataContact1_en_US", (Array:208), NULL)
#13 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Contact/Tokens.php(430): CRM_Utils_Cache_CacheWrapper->set("CRM_Core_EntityTokenstoken_metadataContact1_en_US", (Array:208))
#14 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Core/EntityTokens.php(598): CRM_Contact_Tokens->getTokenMetadata()
#15 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Core/EntityTokens.php(264): CRM_Core_EntityTokens->getMetadataForField("first_name")
#16 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Core/EntityTokens.php(126): CRM_Core_EntityTokens->isMoneyField("first_name")
#17 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Contact/Tokens.php(320): CRM_Core_EntityTokens->evaluateToken(Object(Civi\Token\TokenRow), "contact", "first_name", (Array:24))
#18 /var/www/mysite/web/sites/all/modules/civicrm/vendor/symfony/event-dispatcher/EventDispatcher.php(220): CRM_Contact_Tokens->onEvaluate(Object(Civi\Token\Event\TokenValueEvent), "civi.token.eval", Object(Civi\Core\UnoptimizedEventDispatcher))
#19 /var/www/mysite/web/sites/all/modules/civicrm/vendor/symfony/event-dispatcher/EventDispatcher.php(56): Symfony\Component\EventDispatcher\EventDispatcher->callListeners((Array:26), "civi.token.eval", Object(Civi\Token\Event\TokenValueEvent))
#20 /var/www/mysite/web/sites/all/modules/civicrm/Civi/Core/CiviEventDispatcher.php(263): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Civi\Token\Event\TokenValueEvent), "civi.token.eval")
#21 /var/www/mysite/web/sites/all/modules/civicrm/Civi/Token/TokenProcessor.php(354): Civi\Core\CiviEventDispatcher->dispatch("civi.token.eval", Object(Civi\Token\Event\TokenValueEvent))
#22 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Contact/BAO/Individual.php(221): Civi\Token\TokenProcessor->evaluate()
#23 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Contact/BAO/Contact.php(154): CRM_Contact_BAO_Individual::format((Array:23), Object(CRM_Contact_DAO_Contact))
#24 /var/www/mysite/web/sites/all/modules/civicrm/CRM/Contact/BAO/Contact.php(293): CRM_Contact_BAO_Contact::add((Array:23))
#25 /var/www/mysite/web/sites/all/modules/civicrm/api/v3/Contact.php(571): CRM_Contact_BAO_Contact::create((Array:23))
#26 /var/www/mysite/web/sites/all/modules/civicrm/api/v3/Contact.php(100): _civicrm_api3_contact_update((Array:23), NULL)
#27 /var/www/mysite/web/sites/all/modules/civicrm/Civi/API/Provider/MagicFunctionProvider.php(91): civicrm_api3_contact_create((Array:13))
#28 /var/www/mysite/web/sites/all/modules/civicrm/Civi/API/Kernel.php(164): Civi\API\Provider\MagicFunctionProvider->invoke((Array:8))
#29 /var/www/mysite/web/sites/all/modules/civicrm/Civi/API/Kernel.php(84): Civi\API\Kernel->runRequest((Array:8))
#30 /var/www/mysite/web/sites/all/modules/civicrm/api/api.php(28): Civi\API\Kernel->runSafe("contact", "create", (Array:11))
#31 /var/www/mysite/web/sites/all/modules/webform_civicrm/includes/utils.inc(1666): civicrm_api("contact", "create", (Array:11))
#32 /var/www/mysite/web/sites/all/modules/webform_civicrm/includes/wf_crm_webform_postprocess.inc(644): wf_civicrm_api("contact", "create", (Array:11))
#33 /var/www/mysite/web/sites/all/modules/webform_civicrm/includes/wf_crm_webform_postprocess.inc(148): wf_crm_webform_postprocess->createContact((Array:28))
#34 /var/www/mysite/web/sites/all/modules/webform_civicrm/webform_civicrm.module(255): wf_crm_webform_postprocess->preSave(Object(stdClass))
#35 /var/www/mysite/web/sites/all/modules/webform/includes/webform.submissions.inc(157): webform_civicrm_webform_submission_presave(Object(stdClass), Object(stdClass))
#36 /var/www/mysite/web/sites/all/modules/webform/webform.module(3411): webform_submission_insert(Object(stdClass), Object(stdClass))
#37 /var/www/mysite/web/includes/form.inc(1531): webform_client_form_submit((Array:33), (Array:25))
#38 /var/www/mysite/web/includes/form.inc(906): form_execute_handlers("submit", (Array:33), (Array:25))
#39 /var/www/mysite/web/includes/form.inc(386): drupal_process_form("webform_client_form_2", (Array:33), (Array:25))
#40 /var/www/mysite/web/includes/form.inc(131): drupal_build_form("webform_client_form_2", (Array:25))
#41 /var/www/mysite/web/sites/all/modules/webform/webform.module(2085): drupal_get_form("webform_client_form_2", Object(stdClass), FALSE, FALSE)
#42 /var/www/mysite/web/includes/module.inc(966): webform_node_view(Object(stdClass), "full", "en")
#43 /var/www/mysite/web/modules/node/node.module(1441): module_invoke_all("node_view", Object(stdClass), "full", "en")
#44 /var/www/mysite/web/modules/node/node.module(1336): node_build_content(Object(stdClass), "full", "en")
#45 /var/www/mysite/web/modules/node/node.module(2669): node_view(Object(stdClass), "full", "en")
#46 /var/www/mysite/web/modules/node/node.module(1466): node_view_multiple((Array:1), "full")
#47 /var/www/mysite/web/modules/node/node.module(2761): node_show(Object(stdClass))
#48 /var/www/mysite/web/includes/menu.inc(527): node_page_view(Object(stdClass))
#49 /var/www/mysite/web/index.php(21): menu_execute_active_handler()
#50 {main}
```
