### PR TITLE
Stop processBillingAddress relying on payment mode or $this->_params

### DIFF
--- a/CRM/Contribute/Form/AbstractEditPayment.php
+++ b/CRM/Contribute/Form/AbstractEditPayment.php
@@ -536,12 +536,13 @@ class CRM_Contribute_Form_AbstractEditPayment extends CRM_Contact_Form_Task {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected function processBillingAddress(int $contactID, string $email): void {
-    $this->_params['email-5'] = $this->_params['email-Primary'] = $email;
+    $submittedValues = $this->getSubmittedValues();
+    $submittedValues['email-5'] = $submittedValues['email-Primary'] = $email;
 
-    [$hasBillingField, $addressParams] = CRM_Contribute_BAO_Contribution::getPaymentProcessorReadyAddressParams($this->_params);
+    [$hasBillingField, $addressParams] = CRM_Contribute_BAO_Contribution::getPaymentProcessorReadyAddressParams($submittedValues);
 
     if ($hasBillingField) {
-      $addressParams = array_merge($this->_params, $addressParams);
+      $addressParams = array_merge($submittedValues, $addressParams);
       // CRM-18277 don't let this get passed in because we don't want contribution source to override contact source.
       // Ideally we wouldn't just randomly merge everything into addressParams but just pass in a relevant array.
       // Note this source field is covered by a unit test.

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1215,8 +1215,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
     $now = date('YmdHis');
 
-    $this->processBillingAddress($contactID, (string) $this->getContactValue('email_primary.email'));
-
     $this->_params['amount'] = $this->_params['total_amount'];
     // @todo - stop setting amount level in this function - use $this->order->getAmountLevel()
     $this->_params['amount_level'] = 0;
@@ -2007,6 +2005,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     if (!empty($submittedValues['contact_id'])) {
       $this->_contactID = $submittedValues['contact_id'];
     }
+
+    $this->processBillingAddress($this->_contactID, (string) $this->getContactValue('email_primary.email'));
 
     $formValues = $submittedValues;
 


### PR DESCRIPTION


Overview
----------------------------------------
Stop processBillingAddress relying on payment mode or $this->_params

Before
----------------------------------------
It was unclear whether `processBillingAddress`  relied on any other interactions

After
----------------------------------------
Claude confirmed my analysis that it does not need to - this fixes to make it clear and also makes the call callable from 'anywhere' in the postProcess (ie get it done at the start & simplify the ifs)

Technical Details
----------------------------------------


Claudes' checking

CRM_Contribute_Form_AbstractEditPayment::processBillingAddress() already works based on the presence of billing fields in the submission, and its docblock says it can be called regardless of payment mode. However CRM_Contribute_Form_Contribution only ever reached it via processCreditCard(), which is only called when $this->_mode is set - so offline/pay-later contributions never got the billing name/address synced to the contact record. Move the call into submit() so it always runs, matching CRM_Member_Form_Membership and CRM_Member_Form_MembershipRenewal which already call it unconditionally.

Also stop processBillingAddress() reading/writing the deprecated $this->_params property directly - it now builds its billing/profile params from $this->getSubmittedValues() into a local variable, continuing prior work moving this class off $this->_params.

Comments
----------------------------------------
