### PR TITLE
dev/core#6744 Fixes multiple participant profile leakage in emails

### DIFF
--- a/CRM/Core/WorkflowMessage/ProfileTrait.php
+++ b/CRM/Core/WorkflowMessage/ProfileTrait.php
@@ -51,7 +51,12 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
           $profile['placement'] = $join['weight'] === 1 ? 'pre' : 'post';
           $profile['is_additional_participant'] = $join['module'] === 'CiviEvent_Additional';
           $profile['module'] = $join['module'];
-          if ($join['module'] === 'CiviEvent') {
+          // The primary registrant's own answers live on the 'CiviEvent' join; an
+          // additional participant's own answers live on their 'CiviEvent_Additional'
+          // join instead - each recipient's own pre/post fields must come from
+          // whichever join actually matches the form they filled in.
+          $isOwnProfileJoin = $this->getIsPrimary() ? $join['module'] === 'CiviEvent' : $profile['is_additional_participant'];
+          if ($isOwnProfileJoin) {
             $profile['participant_id'] = $this->getParticipantID();
             try {
               $fields = CRM_Event_BAO_Event::getProfileDisplay([$profile['id']],
@@ -68,10 +73,10 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
             }
             $profile['fields'] = $fields ? $fields[0] : [];
           }
-          elseif ($profile['is_additional_participant']) {
+          elseif ($this->getIsPrimary() && $profile['is_additional_participant']) {
             foreach ($this->getParticipants() as $participant) {
               // Only show the other participants for the primary participant.
-              if ($this->getIsPrimary() && !$participant['is_primary']) {
+              if (!$participant['is_primary']) {
                 if (!isset($profile['fields'])) {
                   $profile['fields'] = [];
                 }
@@ -321,6 +326,13 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
 
   public function getProfilesAdditionalParticipants(): array {
     $profiles = [];
+    // This is the 'list every other participant's answers' block and only
+    // makes sense in the primary's own email - for an additional
+    // participant's own email their 'CiviEvent_Additional' profile has
+    // already been attached as their own pre/post fields instead.
+    if (!$this->getIsPrimary()) {
+      return $profiles;
+    }
     foreach ($this->getProfiles() as $profile) {
       if (!empty($profile['is_additional_participant']) && !empty($profile['fields'])) {
         foreach ($profile['fields'] as $participantIndex => $fields) {

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -362,6 +362,64 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test for https://lab.civicrm.org/dev/core/-/work_items/6744
+   *
+   * When the additional participant's own profile has a field that doesn't
+   * exist on the primary's profile (e.g. a 'relationship to primary' field),
+   * that field should appear in the additional participant's own
+   * confirmation email. Conversely a field that only exists on the
+   * primary's own profile should not appear in the additional participant's
+   * email at all.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testMailAdditionalParticipantOwnProfileFields(): void {
+    $this->eventCreateUnpaid();
+    // Only on the additional participant's own pre-profile - simulates a
+    // field like 'Relationship' that only makes sense for additional
+    // participants.
+    $this->createTestEntity('UFField', [
+      'uf_group_id' => $this->ids['UFGroup']['event_pre_additional_event'],
+      'field_name' => 'nick_name',
+      'label' => 'nick_name',
+    ], 'nick_name');
+    // Only on the primary's own pre-profile - simulates a field like
+    // 'Primary Address' that an additional participant never sees or fills in.
+    $this->createTestEntity('UFField', [
+      'uf_group_id' => $this->ids['UFGroup']['event_pre_event'],
+      'field_name' => 'middle_name',
+      'label' => 'middle_name',
+    ], 'middle_name');
+
+    $form = $this->getTestForm('CRM_Event_Form_Registration_Register', [
+      'first_name' => 'Participant1',
+      'last_name' => 'LastName',
+      'middle_name' => 'PrimaryOnlyField',
+      'email-Primary' => 'participant1@example.com',
+      'additional_participants' => 1,
+    ], ['id' => $this->getEventID()])
+      ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
+        'first_name' => 'Participant2',
+        'last_name' => 'LastName',
+        'nick_name' => 'AdditionalOnlyField',
+        'email-Primary' => 'participant2@example.com',
+      ])
+      ->addSubsequentForm('CRM_Event_Form_Registration_Confirm')
+      ->processForm();
+    $mailSent = $form->getMail();
+
+    // Sanity check - the primary's own field shows up in the primary's own email.
+    $this->assertStringContainsString('middle_name	PrimaryOnlyField', $mailSent[0]['body']);
+
+    // The additional participant's own email should show their own answer
+    // for a field that only exists on their own profile ...
+    $this->assertStringContainsString('nick_name	AdditionalOnlyField', $mailSent[1]['body']);
+    // ... and should not show the primary-only field or its value at all.
+    $this->assertStringNotContainsString('middle_name', $mailSent[1]['body']);
+    $this->assertStringNotContainsString('PrimaryOnlyField', $mailSent[1]['body']);
+  }
+
+  /**
    * Test stock template for multiple participant.
    *
    * The goal is to ensure no leakage.


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#6744 Fixes multiple participant profile leakage in emails

Before
----------------------------------------
The additional participant gets details in their email from the primary participant

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Claude's explanation

CRM_Core_WorkflowMessage_ProfileTrait::getProfiles() always read the primary registrant's own 'CiviEvent' profile join to populate the recipient's own pre/post profile fields, regardless of who the email was actually for. An additional participant's own confirmation email therefore showed the primary's profile fields (blank, since they never filled them in) instead of their own 'CiviEvent_Additional' profile fields, which never got attached to their own email at all.

getProfiles() now selects the join matching the recipient's actual role (CiviEvent for the primary, CiviEvent_Additional for an additional participant) to build their own pre/post fields. getProfilesAdditionalParticipants()
- the 'list every other participant's answers' block used only in the primary's own email - now short-circuits for non-primary recipients so an additional participant's own fields aren't double-counted there.

Also converts callAPISuccess('UFField', 'create', ...) to createTestEntity() in ConfirmTest so newly created fixture data is tracked for teardown.

Comments
----------------------------------------
@seamuslee001 I think this does warrant going against the rc - it is a somewhat recent regression - I guess no good reason not to port to stable afterwards