### PR TITLE
dev/core#6705 Fix additional-participant profile fields silently inheriting the primary's

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2000,8 +2000,12 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   Not used anymore.
    * @param string $usedFor
    *   Deprecated: not clear what this was usedFor.
+   * @param array $extraOptions
+   *   Additional select options to offer alongside the profile list, keyed by the
+   *   value that will be submitted - e.g. ['none' => ts('- none -')]. Use this rather
+   *   than overloading the blank/placeholder value with a non-obvious meaning.
    */
-  public function addProfileSelector($name, $label, $allowCoreTypes, $allowSubTypes = NULL, $entities = NULL, $default = FALSE, $usedFor = NULL) {
+  public function addProfileSelector($name, $label, $allowCoreTypes, $allowSubTypes = NULL, $entities = NULL, $default = FALSE, $usedFor = NULL, array $extraOptions = []) {
     $query = \Civi\Api4\UFGroup::get(TRUE)
       ->addWhere('is_active', '=', 1);
     if (!empty($allowCoreTypes)) {
@@ -2012,7 +2016,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $query->addClause('OR', $clauses);
     }
     $profileGroups = $query->execute()->column('title', 'id');
-    $this->add('select', $name, $label, ['' => ts('- select profile -')] + $profileGroups, FALSE, ['class' => 'crm-select2 huge crm-form-select-profile']);
+    $options = $extraOptions + ['' => ts('- select profile -')] + $profileGroups;
+    $this->add('select', $name, $label, $options, FALSE, ['class' => 'crm-select2 huge crm-form-select-profile']);
     Civi::resources()->addScriptFile('civicrm', 'js/crm.openRelatedConfig.js');
   }
 

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -138,6 +138,11 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
         ];
 
         [$defaults['additional_custom_pre_id'], $defaults['additional_custom_post']] = CRM_Core_BAO_UFJoin::getUFGroupIds($ufJoinAddParams);
+        // No stored join for this event's additional participants can only mean the
+        // user explicitly chose 'none' - postProcess() always writes a join (either
+        // an inherited copy of the primary's profile or an explicit choice) for
+        // every other case.
+        $defaults['additional_custom_pre_id'] = $defaults['additional_custom_pre_id'] ?: 'none';
 
         if (isset($defaults['additional_custom_post']) && is_numeric($defaults['additional_custom_post'])) {
           $defaults['additional_custom_post_id'] = $defaults['additional_custom_post'];
@@ -152,6 +157,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
             $defaults["additional_custom_post_id_multiple[$key]"] = $value;
           }
         }
+        $defaults['additional_custom_post_id'] = $defaults['additional_custom_post_id'] ?? 'none';
         $this->assign('profilePostMultipleAdd', $defaults['additional_custom_post'] ?? []);
       }
       else {
@@ -161,6 +167,10 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     }
     else {
       $defaults['is_email_confirm'] = 0;
+      // For a brand-new event, default to inheriting the primary's profile
+      // choices, matching the traditional convenience default.
+      $defaults['additional_custom_pre_id'] = 'inherit';
+      $defaults['additional_custom_post_id'] = 'inherit';
     }
 
     // provide defaults for required fields if empty (and as a 'hint' for approval message field)
@@ -286,8 +296,25 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     extract(self::getProfileSelectorTypes());
     $this->addProfileSelector('custom_pre_id', ts('Top Profile Fields'), $allowCoreTypes);
     $this->addProfileSelector('custom_post_id', ts('Bottom Profile Fields'), $allowCoreTypes);
-    $this->addProfileSelector('additional_custom_pre_id', ts('Top Profile Fields for Additional Participants'), $allowCoreTypes);
-    $this->addProfileSelector('additional_custom_post_id', ts('Bottom Profile Fields for Additional Participants'), $allowCoreTypes);
+    $this->addProfileSelector('additional_custom_pre_id', ts('Top Profile Fields for Additional Participants'), $allowCoreTypes, extraOptions: self::getAdditionalProfileExtraOptions());
+    $this->addProfileSelector('additional_custom_post_id', ts('Bottom Profile Fields for Additional Participants'), $allowCoreTypes, extraOptions: self::getAdditionalProfileExtraOptions());
+  }
+
+  /**
+   * Get the extra (non-profile) options for the additional-participant profile selectors.
+   *
+   * Unlike the primary participant's profile selectors, these have a concept of
+   * inheriting the primary's own choice, or being explicitly blank. Both are
+   * given explicit values here rather than relying on the blank/placeholder
+   * option, which has no consistent meaning at save time.
+   *
+   * @return array
+   */
+  private static function getAdditionalProfileExtraOptions(): array {
+    return [
+      'inherit' => ts('Same as primary participant'),
+      'none' => ts('- none -'),
+    ];
   }
 
   /**
@@ -485,7 +512,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
         //check for additional custom pre profile
         $additionalCustomPreId = $values['additional_custom_pre_id'] ?? NULL;
-        if (!empty($additionalCustomPreId)) {
+        if (!empty($additionalCustomPreId) && $additionalCustomPreId !== 'inherit') {
           if (!($additionalCustomPreId == 'none')) {
             $customPreId = $additionalCustomPreId;
           }
@@ -513,7 +540,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
         // We don't have required Individual fields in the pre-custom profile, so now check the post-custom profile
         if ($isPreError) {
           $additionalCustomPostId = $values['additional_custom_post_id'] ?? NULL;
-          if (!empty($additionalCustomPostId)) {
+          if (!empty($additionalCustomPostId) && $additionalCustomPostId !== 'inherit') {
             if (!($additionalCustomPostId == 'none')) {
               $customPostId = $additionalCustomPostId;
             }
@@ -825,26 +852,25 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
       $ufAdd = [];
       $wtAdd = 2;
 
+      // 'inherit' explicitly means copy the primary's profile; 'none' (or blank,
+      // for anything submitting outside the form's own select options) explicitly
+      // means no additional profile - leave $ufAdd unset for that slot.
       if (array_key_exists('additional_custom_pre_id', $params)) {
-        if (empty($params['additional_custom_pre_id'])) {
+        if (($params['additional_custom_pre_id'] ?? NULL) === 'inherit') {
           $ufAdd[1] = $params['custom_pre_id'];
           $wtAdd = 1;
         }
-        elseif (($params['additional_custom_pre_id'] ?? NULL) == 'none') {
-        }
-        else {
+        elseif (!empty($params['additional_custom_pre_id']) && $params['additional_custom_pre_id'] !== 'none') {
           $ufAdd[1] = $params['additional_custom_pre_id'];
           $wtAdd = 1;
         }
       }
 
       if (array_key_exists('additional_custom_post_id', $params)) {
-        if (empty($params['additional_custom_post_id'])) {
+        if (($params['additional_custom_post_id'] ?? NULL) === 'inherit') {
           $ufAdd[2] = $params['custom_post_id'];
         }
-        elseif (($params['additional_custom_post_id'] ?? NULL) == 'none') {
-        }
-        else {
+        elseif (!empty($params['additional_custom_post_id']) && $params['additional_custom_post_id'] !== 'none') {
           $ufAdd[2] = $params['additional_custom_post_id'];
         }
       }

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/RegistrationTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/RegistrationTest.php
@@ -1,6 +1,13 @@
 <?php
 
+use Civi\Api4\Event;
+use Civi\Api4\UFGroup;
+use Civi\Api4\UFJoin;
+use Civi\Test\FormTrait;
+
 class CRM_Event_Form_ManageEvent_RegistrationTest extends CiviUnitTestCase {
+
+  use FormTrait;
 
   /**
    * Set up a correct array of form values.
@@ -41,6 +48,98 @@ class CRM_Event_Form_ManageEvent_RegistrationTest extends CiviUnitTestCase {
     $form = new CRM_Event_Form_ManageEvent_Registration();
     $validationResult = \CRM_Event_Form_ManageEvent_Registration::formRule($values, [], $form);
     $this->assertArrayHasKey('registration_end_date', $validationResult);
+  }
+
+  /**
+   * Test for https://lab.civicrm.org/dev/core/-/work_items/6705
+   *
+   * Leaving "Bottom Profile Fields for Additional Participants" unselected
+   * must not silently inherit the primary participant's own profile - that
+   * now requires explicitly choosing 'inherit'. Leaving it blank (or
+   * choosing the explicit '- none -' option) must result in no additional
+   * profile at all - including on a second save where the field is still
+   * left blank, to guard against blank being reinterpreted as 'inherit'.
+   */
+  public function testAdditionalParticipantProfileNotInheritedWhenBlank(): void {
+    $eventID = $this->createTestEvent();
+    $primaryPostProfileID = $this->createTestProfile();
+    $additionalPreProfileID = $this->createTestProfile();
+
+    $formValues = [
+      'is_online_registration' => 1,
+      'is_multiple_registrations' => 1,
+      'max_additional_participants' => 9,
+      'custom_post_id' => $primaryPostProfileID,
+      'additional_custom_pre_id' => $additionalPreProfileID,
+      'additional_custom_post_id' => '',
+      'is_email_confirm' => 0,
+      'is_template' => 0,
+      'registration_start_date' => '2029-09-08',
+      'registration_end_date' => '2029-09-20',
+    ];
+    $this->getTestForm('CRM_Event_Form_ManageEvent_Registration', $formValues, ['id' => $eventID])->processForm();
+
+    $profileIDs = UFJoin::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_event')
+      ->addWhere('entity_id', '=', $eventID)
+      ->addWhere('module', '=', 'CiviEvent_Additional')
+      ->execute()->indexBy('uf_group_id');
+    // Only the pre is found - the post profile is 'null' - ie do not inherit the primary's post profile
+    $this->assertEquals($additionalPreProfileID, $profileIDs->single()['uf_group_id']);
+
+    // Save again with the field still blank - it must stay unset, not drift
+    // towards inheriting the primary's profile on a subsequent save.
+    $this->getTestForm('CRM_Event_Form_ManageEvent_Registration', $formValues, ['id' => $eventID])->processForm();
+    $profileIDs = UFJoin::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_event')
+      ->addWhere('entity_id', '=', $eventID)
+      ->addWhere('module', '=', 'CiviEvent_Additional')
+      ->execute()->indexBy('uf_group_id');
+    // A second save with the field still blank must not inherit the primary\'s post profile either.
+    $this->assertEquals($additionalPreProfileID, $profileIDs->single()['uf_group_id']);
+  }
+
+  /**
+   * Explicitly choosing 'inherit' should copy the primary's profile.
+   */
+  public function testAdditionalParticipantProfileInheritsWhenExplicit(): void {
+    $eventID = $this->createTestEvent();
+    $primaryPostProfileID = $this->createTestProfile();
+
+    $this->getTestForm('CRM_Event_Form_ManageEvent_Registration', [
+      'is_online_registration' => 1,
+      'is_multiple_registrations' => 1,
+      'max_additional_participants' => 9,
+      'custom_post_id' => $primaryPostProfileID,
+      'additional_custom_post_id' => 'inherit',
+      'registration_start_date' => '2028-09-01',
+      'registration_end_date' => '2028-09-06',
+      'is_template' => 0,
+      'is_email_confirm' => 0,
+    ], ['id' => $eventID])->processForm();
+
+    $profileIDs = UFJoin::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_event')
+      ->addWhere('entity_id', '=', $eventID)
+      ->addWhere('module', '=', 'CiviEvent_Additional')
+      ->execute()->column('uf_group_id');
+    $this->assertEquals([$primaryPostProfileID], $profileIDs);
+  }
+
+  private function createTestEvent(): int {
+    return (int) Event::create(FALSE)->setValues([
+      'title' => 'Test event',
+      'event_type_id' => 1,
+      'start_date' => date('Y-m-d'),
+      'is_active' => TRUE,
+    ])->execute()->first()['id'];
+  }
+
+  private function createTestProfile(): int {
+    return (int) UFGroup::create(FALSE)->setValues([
+      'title' => 'Test profile ' . uniqid(),
+      'group_type' => 'Individual,Contact',
+    ])->execute()->first()['id'];
   }
 
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3095,6 +3095,11 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
    *
    * We need to instantiate the form to run preprocess, which means we have to trick it about the request method.
    *
+   * @deprecated prefer \Civi\Test\FormTrait::getTestForm(), which wraps this same
+   *   instantiation logic but also offers processForm()/addSubsequentForm() to
+   *   drive the form through its lifecycle without each test reimplementing
+   *   preProcess()/buildForm()/postProcess() calls by hand.
+   *
    * @param string $class
    *   Name of form class.
    *


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6705 Fix additional-participant profile fields silently inheriting the primary's

This is a fairly old regression & it doesn't apply cleanly on 6.19 so I am targetting master

Before
----------------------------------------
When selection profiles for managed events we used to use 'the backbone thing' - it submitted 'none' when no profile was selected for additional participants. With it removed the 'none' went and the `''` option is 'use the same profile as the primary profile' so the primary profile was used for additional participants - despite the admin's intent

After
----------------------------------------
At the form level `''` is gone in favour of explicit `none` and `inherit`

Technical Details
----------------------------------------

Claudes notes

CRM_Event_Form_ManageEvent_Registration used a blank submission of additional_custom_pre_id/additional_custom_post_id to mean "inherit the primary participant's profile" - a meaning that was only reachable via the old Backbone profile-selector widget's explicit 'none' option. Since that widget was replaced with a plain <select> (1b0c6e79fb), leaving these fields unselected always submits blank, so admins who deliberately leave "Bottom Profile Fields for Additional Participants" empty (to collect less information from additional participants) get the primary's profile silently copied in on save instead.

Overloading blank to mean "inherit" was also fragile in a second way: once a field is saved as explicitly empty (no UFJoin row), setDefaultValues() had no way to redisplay that as anything other than blank, so re-saving without touching the field again would re-trigger the same inherit fallback.

Fix: give addProfileSelector() a generic $extraOptions parameter, and use it to add two explicit values for the additional-participant selectors - 'inherit' (copy the primary's profile) and 'none' (no profile). Blank is no longer special-cased at save time; only 'inherit' triggers the copy. setDefaultValues() now redisplays a missing join as 'none' (the only way it can arise once a row has ever been saved) rather than blank, and defaults a brand-new event to 'inherit' for its traditional convenience-default behaviour.


Comments
----------------------------------------
@aydun are you able to test / confirm this?
