### PR TITLE
dev/core#6740 Fix fatal error cancelling a pledge

### DIFF
--- a/CRM/Pledge/Page/Tab.php
+++ b/CRM/Pledge/Page/Tab.php
@@ -119,6 +119,7 @@ class CRM_Pledge_Page_Tab extends CRM_Core_Page {
     elseif ($this->_action & CRM_Core_Action::DETACH) {
       CRM_Pledge_BAO_Pledge::cancel($this->_id);
       CRM_Core_Session::setStatus(ts('Pledge has been cancelled and all scheduled (not completed) payments have been cancelled.'));
+      $session = CRM_Core_Session::singleton();
       CRM_Utils_System::redirect($session->popUserContext());
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
Cancelling a pledge from a contact's Pledges tab throws a fatal error instead of cancelling the pledge, when the AdminUI extension is not enabled.

Before
----------------------------------------
`CRM_Pledge_Page_Tab::run() redirects via $session->popUserContext()` on the cancel (DETACH) branch, but $session is never defined in that scope. Regression from f14569ec9c ("[NFC] setStatus is a static function"), which converted `$session->setStatus()` to the static CRM_Core_Session::setStatus() and dropped the
$session = CRM_Core_Session::singleton(); line, missing that the next line still needed it. Result: Error: Call to a member function popUserContext() on null.

After
----------------------------------------
$session is assigned before use again; cancelling a pledge redirects back to the previous context as before.

Technical Details
----------------------------------------
git log -L confirmed the line was removed in f14569ec9c, and that no other file touched by that commit was left with a similarly dangling $session reference.
