### PR TITLE
dev/core#6730 Stop offering "Submit Credit Card payment" against a refund balance

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3302,7 +3302,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'weight' => 0,
     ];
 
-    if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
+    if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments() && self::getContributionBalance($id) >= 0) {
+      // A negative balance means a refund is owed, not a payment - submitting a credit card
+      // "payment" against a refund silently fails (the processor is never called) because
+      // the credit-card submission path does not support refunds. See dev/core#6730.
       $actionLinks[] = [
         'url' => 'civicrm/payment',
         'title' => ts('Submit Credit Card payment'),


### PR DESCRIPTION
Overview
----------------------------------------
The back-office "Submit Credit Card payment" action was reachable against a contribution with a negative balance (a refund owed), but that combination silently does nothing - no request ever reaches the payment processor and no error is shown to the admin.

Before
----------------------------------------
CRM_Contribute_BAO_Contribution::getContributionPaymentLinks() offered the "Submit Credit Card payment" link unconditionally whenever back-office credit card payments were enabled, regardless of whether the contribution's balance was positive (payment owed) or negative (refund owed). Submitting it against a negative balance appeared to succeed but never called the payment processor: the credit-card submission path (CRM_Contribute_Form_AdditionalPayment:: processCreditCard()) has no support for refunds, and a separate guard in preProcess() that blocks live-mode refunds was never reached from this link because it was never gated out at the UI level.

This combination was unreachable before dev/core#6497 c4cbe461a4d ("Make 'Record Payment' & 'Record Refund' visible regardless of whether the balance 'requires' one", 2020-09-09), which deliberately removed a `(int) $balance > 0` guard around this link acting on a pre-existing @todo ("this should be possible even if not > 0 - test and remove this if"). That guard's removal is what made the negative balance / credit-card-payment combination reachable, exposing this otherwise-latent gap.

After
----------------------------------------
"Submit Credit Card payment" is only offered when the contribution's balance is not negative. A negative balance still offers "Record Refund" as before; a manual/processor-side refund flow remains the correct path.

Technical Details
----------------------------------------
Restores a balance check via CRM_Contribute_BAO_Contribution:: getContributionBalance($id), preserving the 2020 change's intent for the balance = 0 case (still offered) while blocking only the negative case that has no support downstream.

This only closes the unsafe UI entry point. It does not add processor- side refund support to the credit-card submission path (wiring a genuine "submit refund to processor" flow through
Civi\Api4\Action\PaymentProcessor\Refund, as suggested on the issue, would be a separate, larger change) and does not change the silent failure of preProcess()'s existing live-mode-refund guard should this combination still be reached some other way (e.g. a hand-built URL). 

Comments
----------------------------------------


@mattwire .....