### PR TITLE
dev/core#6670: Cast operands to int in getParticipantCount() and vali…

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1066,7 +1066,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
             continue;
           }
           foreach ($value as $optId => $optVal) {
-            $currentCount = $priceSetFields[$priceFieldId]['options'][$optId] * $optVal;
+            $currentCount = (int) ($priceSetFields[$priceFieldId]['options'][$optId] ?? 0) * (int) $optVal;
             if ($currentCount) {
               $count += $currentCount;
             }
@@ -1467,7 +1467,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
             $currentMaxValue = 1;
           }
           if (isset($optionsCountDetails[$priceFieldId], $optionsCountDetails[$priceFieldId]['options'][$optId])) {
-            $currentMaxValue = $optionsCountDetails[$priceFieldId]['options'][$optId] * $optVal;
+            $currentMaxValue = (int) ($optionsCountDetails[$priceFieldId]['options'][$optId] ?? 0) * (int) $optVal;
           }
           $optionMaxValues[$priceFieldId][$optId] = $currentMaxValue + ($optionMaxValues[$priceFieldId][$optId] ?? 0);
           if ($pNum !== $currentParticipantNo) {


### PR DESCRIPTION
Overview
--------------------------------
Casts operands to int in `getParticipantCount()` and `validatePriceSet()` in `CRM/Event/Form/Registration.php` to prevent a TypeError when a price field option has an unset count.

Fixes dev/core#6670

Before
--------------------------------
A TypeError was thrown on the Event Registration price field count calculation when a price field option's count was unset (null), because the multiplication operated on a null operand.

After
--------------------------------
The count and max value calculations now cast both operands to `(int)`, using `?? 0` as a fallback when the value is unset, so the multiplication always operates on integers and no longer throws.

Technical Details
--------------------------------
Two lines changed:
- Line 1069 in `getParticipantCount()`: `$currentCount = (int) ($priceSetFields[$priceFieldId]['options'][$optId] ?? 0) * (int) $optVal;`
- Line 1470 in `validatePriceSet()`: `$currentMaxValue = (int) ($optionsCountDetails[$priceFieldId]['options'][$optId] ?? 0) * (int) $optVal;`

Comments
--------------------------------
Reported by Eileen (see dev/core#6670). Small, focused fix — no other behavior changed.