### PR TITLE
dev/core#6713 Block enabling a reserved group without permission

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -751,6 +751,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterfa
           $action -= CRM_Core_Action::DELETE;
           $action -= CRM_Core_Action::UPDATE;
           $action -= CRM_Core_Action::DISABLE;
+          $action -= CRM_Core_Action::ENABLE;
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Enable/disable action links for a reserved group were only partly gated by the 'administer reserved groups' permission, letting a user without that permission re-enable a group they should not be able to touch.

Before
----------------------------------------
CRM_Contact_BAO_Group.php strips DELETE, UPDATE, and DISABLE from a reserved group's action bitmask when the current user lacks 'administer reserved groups', but never strips ENABLE. For an active reserved group that's harmless (ENABLE is already excluded elsewhere, since it's not relevant to an active group), but for a group that is already disabled, nothing blocks ENABLE - so a user without the permission could re-enable it.

After
----------------------------------------
ENABLE is stripped alongside DELETE/UPDATE/DISABLE, so a disabled reserved group can only be re-enabled by a user with 'administer reserved groups'.

Technical Details
----------------------------------------
One-line addition: $action -= CRM_Core_Action::ENABLE; in the is_reserved permission-gating block.

Comments
----------------------------------------
Confirmed via git log -L that this block (and the gap) dates to the original 2013 SVN import - not a regression, ENABLE was simply never added alongside the other three actions.

