### PR TITLE
dev/core#6702 Fix fatal error reactivating a relationship when the owning contact has multiple memberships

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -2231,6 +2231,8 @@ SELECT count(*)
       $extraneousIncomingKeys = [
         'membership_type_id.relationship_type_id',
         'membership_type_id.relationship_direction',
+        'owner_membership_id.contact_id',
+        'owner_contact_id',
         'inheriting_membership_ids',
         'inheriting_contact_ids',
         'relationship_type_ids',

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -12,6 +12,7 @@
 use Civi\Api4\Membership;
 use Civi\Api4\MembershipLog;
 use Civi\Api4\MembershipStatus;
+use Civi\Api4\Relationship;
 use Civi\Test\ContributionPageTestTrait;
 use Civi\Api4\Payment;
 
@@ -38,6 +39,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
    * This method is called after a test is executed.
    */
   public function tearDown(): void {
+    Relationship::delete(FALSE)->addWhere('id', '>', 0)->execute();
     $this->quickCleanUpFinancialEntities();
     parent::tearDown();
   }
@@ -809,7 +811,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
         'contact_id_a'         => $contactID,
         'contact_id_b'         => $employerId,
         'is_active'            => 1,
-      ]);
+      ], 'employee_' . $contactID);
     }
     $this->deleteRelatedMemberships($membership["id"]);
     $this->assertEquals(0, $this->getRelatedMembershipsCount($membership["id"]), 'Related membership count should be 0.');
@@ -883,6 +885,70 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     $this->callAPISuccess('Relationship', 'delete', ['id' => $this->ids['Relationship']['default']]);
     $relatedMembershipsCount = $this->getRelatedMembershipsCount($membership["id"]);
     $this->assertEquals(0, $relatedMembershipsCount, 'Related membership count should be 0.');
+  }
+
+  /**
+   * Test done to verify bug dev/core#6702 remains fixed.
+   *
+   * Reactivating a relationship (e.g. 'Employee of') used to fatal with
+   * "Expected to find one Membership record, but there were multiple" if the
+   * owning contact (e.g. the employer) held more than one membership.
+   *
+   * This happened because CRM_Member_Utils_RelationshipProcessor::setMemberships()
+   * includes the joined field 'owner_membership_id.contact_id' (and a derived
+   * 'owner_contact_id') on every fetched membership row, and these keys were not
+   * filtered out before being passed to Membership::save() in
+   * CRM_Contact_BAO_Relationship::addInheritedMembership(). APIv4 then tried to
+   * resolve 'owner_membership_id' via a lookup on Membership.contact_id, which
+   * fatals if that contact has more than one membership.
+   *
+   * https://lab.civicrm.org/dev/core/-/issues/6702
+   */
+  public function testReactivatingRelationshipWithMultipleOwnerMembershipsDoesNotFatal(): void {
+    $membershipOrganizationId = $this->organizationCreate();
+    $employerId = $this->organizationCreate();
+
+    $membershipTypeWithRelationship = $this->createMembershipType($membershipOrganizationId, TRUE);
+    $membership = $this->createTestEntity('Membership', [
+      'membership_type_id' => $membershipTypeWithRelationship['id'],
+      'contact_id' => $employerId,
+      'status_id' => $this->_membershipStatusID,
+    ], 'owner');
+
+    // Give the employer a second, unrelated membership - this is what makes a
+    // lookup of "the Membership belonging to this contact" ambiguous.
+    $otherMembershipType = $this->createMembershipType($this->organizationCreate());
+    $this->createTestEntity('Membership', [
+      'membership_type_id' => $otherMembershipType['id'],
+      'contact_id' => $employerId,
+      'status_id' => $this->_membershipStatusID,
+    ], 'other');
+
+    $employeeId = $this->individualCreate();
+    $relationship = $this->createTestEntity('Relationship', [
+      'relationship_type_id:name' => 'Employee of',
+      'contact_id_a' => $employeeId,
+      'contact_id_b' => $employerId,
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(1, $this->getRelatedMembershipsCount($membership['id']));
+
+    // Deactivate then reactivate the relationship - this is the flow that
+    // triggered the fatal error.
+    Relationship::update(FALSE)
+      ->addWhere('id', '=', $relationship['id'])
+      ->setValues(['is_active' => 0])
+      ->execute();
+    Relationship::update(FALSE)
+      ->addWhere('id', '=', $relationship['id'])
+      ->setValues(['is_active' => 1])
+      ->execute();
+
+    $relatedMembership = Membership::get(FALSE)
+      ->addWhere('contact_id', '=', $employeeId)
+      ->addWhere('owner_membership_id', '=', $membership['id'])
+      ->execute()->single();
+    $this->assertEquals($membership['id'], $relatedMembership['owner_membership_id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Reactivating (or creating) a relationship such as 'Employee of' could fatal with "Expected to find one Membership record, but there were multiple" whenever the owning contact (e.g. the employer) held more than one membership.

Note this is the patch that @VangelisP  proposed on the gitlab - the function is well tested

Before
----------------------------------------
CRM_Member_Utils_RelationshipProcessor::setMemberships() fetches membership rows with several joined fields, including 'owner_membership_id.contact_id' - and derives an 'owner_contact_id' key from it. Both keys survive on the array all the way into CRM_Contact_BAO_Relationship::addInheritedMembership(), which strips a fixed list of "extraneous" incoming keys before calling Membership::save()->addRecord(...) - but that list did not include either of these two keys.

APIv4's join-permission-aware FK resolution (dev/core#6746 is a related but separate gap in that same area) sees the dotted key 'owner_membership_id.contact_id' still present in the params and tries to resolve 'owner_membership_id' via a lookup on Membership.contact_id = <that value>, even though the correct owner_membership_id was already set directly a few lines earlier. If the owning contact has more than one membership, that lookup is ambiguous and throws instead of silently picking one.

After
----------------------------------------
'owner_membership_id.contact_id' and 'owner_contact_id' are added to the extraneousIncomingKeys filter list, so they never reach Membership::save(). The already-correct, explicitly-set owner_membership_id value is used as-is.

Technical Details
----------------------------------------
Two-line addition to CRM_Contact_BAO_Relationship:: addInheritedMembership()'s $extraneousIncomingKeys array.

Comments
----------------------------------------
Targets the 6.19 branch (current RC) since this is a regression - reported as introduced by e4630c3ea6 ("Api4 - Check permissions when creating with joined entity values."), which switched FK resolution from a permissive CRM_Core_DAO::getFieldValue() lookup to a strict API4 ->single() lookup.

Added CRM_Member_BAO_MembershipTest::
testReactivatingRelationshipWithMultipleOwnerMembershipsDoesNotFatal()
- gives the employer contact two memberships, creates an active 'Employee of' relationship, then deactivates and reactivates it (matching the reported repro), asserting no fatal and that the correct owner_membership_id is used.

