### PR TITLE
dev/core#6699 Fix mandatory CheckBoxes/CheckBox settings not showing as defaults

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -206,6 +206,17 @@ trait CRM_Admin_Form_SettingTrait {
       // Disable input when values are overridden in civicrm.settings.php.
       $mandatory = Civi::settings()->getMandatory($settingName);
       if ($mandatory !== NULL) {
+        // Shape the value the same way setDefaultsForMetadataDefinedFields() shapes
+        // DB/API-sourced defaults for these field types. Without this,
+        // CRM_Core_Form::buildForm()'s merge of mandatory values over $this->_defaults
+        // clobbers a correctly-shaped default with one QuickForm's default-matching
+        // does not recognise, leaving the field looking empty/unchecked (dev/core#6699).
+        if ($quickFormType === 'CheckBoxes' && is_array($mandatory)) {
+          $mandatory = array_fill_keys($mandatory, 1);
+        }
+        elseif ($quickFormType === 'CheckBox') {
+          $mandatory = [$settingName => $mandatory];
+        }
         $this->mandatoryValues[$settingName] = $mandatory;
       }
 


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#6699 Fix mandatory CheckBoxes/CheckBox settings not showing as defaults

Before
----------------------------------------
CRM_Admin_Form_SettingTrait::addSettingFieldToForm() stored the raw mandatory value from civicrm.settings.php as-is (e.g. a plain list ['sort_name', 'first_name']). CRM_Core_Form::buildForm() then merges that value over the correctly-shaped default (['sort_name' => 1, ...]) built by setDefaultsForMetadataDefinedFields() - and because the mandatory value comes last in that merge, it silently clobbered the correct shape with one QuickForm's checkbox-group default matching does not recognise. String-type mandatory settings were unaffected; only CheckBoxes/CheckBox-type fields showed this.

After
----------------------------------------
The mandatory value is shaped the same way as the DB/API-sourced default before being stored, so it renders correctly whichever one wins the merge.

Technical Details
----------------------------------------
Reuses the same per-field-type transform setDefaultsForMetadataDefinedFields() already applies (array_fill_keys() for CheckBoxes, wrap-in-array for CheckBox), applied at the point addSettingFieldToForm() captures the mandatory value.

Comments
----------------------------------------
Targets master since this is a longstanding gap in addSettingFieldToForm(), not a regression.
