### PR TITLE
dev/core#6664 Add regression test for additional-participant profile title

### DIFF
--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -362,6 +362,19 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test the additional participants' profile section headers use the
+   * public (frontend) title rather than the admin title.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testMailMultipleParticipantProfileTitleIsFrontEndTitle(): void {
+    $this->createScenarioMultipleParticipantPendingFreeEvent();
+    $mailSent = $this->sentMail;
+    $this->assertStringContainsString('Public Event Pre Profile (Additional)', $mailSent[0]['body']);
+    $this->assertStringNotContainsString('>Event Pre Profile (Additional)', $mailSent[0]['body']);
+  }
+
+  /**
    * Test stock template for multiple participant.
    *
    * The goal is to ensure no leakage.


### PR DESCRIPTION

Already fixed on master by fb4bb3c2d4 (2026-03-27), before this issue was reported - getProfilesAdditionalParticipants() now reads frontend_title instead of title. This just locks in the fix.
