### PR TITLE
dev/core#6696 Stop shared-address relationships piling up when disabled

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1162,7 +1162,16 @@ SELECT is_primary,
 
     // If already there is a relationship record of $relParam criteria, avoid creating relationship again or else
     // it will casue CRM-16588 as the Duplicate Relationship Exception will revert other contact field values on update
-    if (CRM_Contact_BAO_Relationship::checkDuplicateRelationship($relParam, (int) $currentContactId, (int) $sharedContactId)) {
+    // Note we deliberately do not use CRM_Contact_BAO_Relationship::checkDuplicateRelationship() here as it only
+    // matches active relationships, which would let this create a fresh active duplicate every time the shared
+    // address is re-saved if the existing relationship had been deliberately disabled (dev/core#6696).
+    $existingRelationship = \Civi\Api4\Relationship::get(FALSE)
+      ->addWhere('relationship_type_id', '=', $relTypeId)
+      ->addWhere('contact_id_a', '=', $currentContactId)
+      ->addWhere('contact_id_b', '=', $sharedContactId)
+      ->selectRowCount()
+      ->execute();
+    if (count($existingRelationship)) {
       return;
     }
 

--- a/tests/phpunit/CRM/Core/BAO/AddressTest.php
+++ b/tests/phpunit/CRM/Core/BAO/AddressTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Relationship;
+
 /**
  * Class CRM_Core_BAO_AddressTest
  * @group headless
@@ -735,6 +737,72 @@ class CRM_Core_BAO_AddressTest extends CiviUnitTestCase {
 
     // CRM-21214 - AdressA shouldn't be master of itself.
     $this->assertEmpty($updatedAddressA->master_id);
+  }
+
+  /**
+   * Re-saving a shared address should not duplicate a disabled auto-created
+   * relationship.
+   *
+   * When a contact shares a household's address, saving that address
+   * auto-creates an active 'Household Member of' relationship. If the
+   * member deliberately disables that relationship, re-saving the
+   * household's address (e.g. editing the household record without
+   * changing the address) should not create a second, active, duplicate
+   * relationship.
+   *
+   * https://lab.civicrm.org/dev/core/-/issues/6696
+   */
+  public function testSharedAddressDoesNotDuplicateDisabledRelationship(): void {
+    $householdId = $this->createTestEntity('Contact', [
+      'contact_type' => 'Household',
+      'household_name' => 'Adams Family',
+    ], 'household')['id'];
+    $memberId = $this->individualCreate();
+
+    $householdAddressId = $this->createTestEntity('Address', [
+      'street_address' => '123 Fake St.',
+      'location_type_id' => 1,
+      'is_primary' => 1,
+      'contact_id' => $householdId,
+    ], 'household')['id'];
+
+    // Saving the member's address, sharing the household's, auto-creates an
+    // active 'Household Member of' relationship.
+    $this->createTestEntity('Address', [
+      'street_address' => '123 Fake St.',
+      'location_type_id' => 1,
+      'is_primary' => 1,
+      'master_id' => $householdAddressId,
+      'contact_id' => $memberId,
+    ], 'member');
+
+    $relationships = Relationship::get(FALSE)
+      ->addWhere('contact_id_a', '=', $memberId)
+      ->addWhere('contact_id_b', '=', $householdId)
+      ->addWhere('relationship_type_id:name', '=', 'Household Member of')
+      ->execute();
+    $this->assertCount(1, $relationships);
+
+    // The member deliberately disables the relationship...
+    Relationship::update(FALSE)
+      ->addWhere('id', '=', $relationships->first()['id'])
+      ->setValues(['is_active' => FALSE])
+      ->execute();
+
+    // ...but the household's address is re-saved unchanged (e.g. the
+    // household record is edited & saved without touching the address).
+    \Civi\Api4\Address::update(FALSE)
+      ->addWhere('id', '=', $householdAddressId)
+      ->setValues(['street_address' => '123 Fake St.'])
+      ->execute();
+
+    $relationships = Relationship::get(FALSE)
+      ->addWhere('contact_id_a', '=', $memberId)
+      ->addWhere('contact_id_b', '=', $householdId)
+      ->addWhere('relationship_type_id:name', '=', 'Household Member of')
+      ->execute();
+    $this->assertCount(1, $relationships, 'Re-saving the shared address should not create a duplicate relationship.');
+    $this->assertFalse((bool) $relationships->first()['is_active'], 'The existing disabled relationship should remain disabled, not be duplicated as active.');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When a contact shares a household's (or organization's) address, saving that address auto-creates an active "Household Member of" relationship (or current-employer, for an organization) between them. If the user deliberately disables that relationship, then later re-saves the household record - even without touching the address - the relationship comes back, active again. Disable it again, re-save again, and another one appears. Repeating this indefinitely leaves the contact with one active relationship and an ever-growing pile of disabled duplicates (dev/core#6696).

The issue itself raises two possible fixes, and neither the submitter nor anyone else has expressed a strong preference between them: (a) reactivate the existing disabled relationship instead of creating a new one, or (b) leave it alone - don't auto-create anything if a relationship (active or not) already exists, so the disabled one stays disabled. This goes with (b), since it's the smaller change and respects a deliberate "no" from the user without guessing whether they want it silently reversed.

Before
----------------------------------------
Re-saving a shared address with a deliberately-disabled auto-created relationship recreated that relationship as active, and repeating the disable/re-save cycle kept adding further disabled duplicates.

After
----------------------------------------
Re-saving the address is a no-op if a relationship of the relevant type already exists between the two contacts, active or not. A disabled relationship stays disabled instead of accumulating duplicates.

Technical Details
----------------------------------------
CRM_Core_BAO_Address::processSharedAddressRelationship() used CRM_Contact_BAO_Relationship::checkDuplicateRelationship() to avoid creating a relationship that already exists. That helper's query hardcodes `is_active = 1`, so it can only ever see existing *active* relationships - a disabled one is invisible to it, and a fresh active duplicate gets created on every save.

Replaced the checkDuplicateRelationship() call in
processSharedAddressRelationship() with a direct
Civi\Api4\Relationship::get() existence check that does not filter on is_active. checkDuplicateRelationship() itself is left unchanged, since its is_active-only matching is relied on by its other callers.

Added CRM_Core_BAO_AddressTest::
testSharedAddressDoesNotDuplicateDisabledRelationship() - creates a household + member sharing an address (auto-creating an active relationship), disables that relationship, then re-saves the household's address and asserts no duplicate is created. Uses createTestEntity()/APIv4 throughout.

