### PR TITLE
dev/core#6386 Fix "Event Active On" search excluding events already in progress

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -7078,6 +7078,11 @@ AND   displayRelType.is_active = 1
       return;
     }
 
+    if ($fieldName === 'event') {
+      $this->_where[$grouping][] = CRM_Event_BAO_Query::getEventActiveOnClause($dates[0], $dates[1]);
+      return;
+    }
+
     if (empty($dates[0])) {
       // ie. no start date we only have end date
       $this->_where[$grouping][] = $secondWhere . " <= '{$dates[1]}'";

--- a/CRM/Event/BAO/Query.php
+++ b/CRM/Event/BAO/Query.php
@@ -300,9 +300,12 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
     switch ($name) {
       case 'event_low':
       case 'event_high':
-        $query->dateQueryBuilder($values,
-          'civicrm_event', 'event', 'start_date', ts('Event Active On'), TRUE, 'YmdHis', 'end_date'
-        );
+        $dateValueLow = $query->getWhereValues('event_low', $grouping);
+        $dateValueHigh = $query->getWhereValues('event_high', $grouping);
+        if ($name !== (empty($dateValueLow[2]) ? 'event_high' : 'event_low')) {
+          return;
+        }
+        self::addEventActiveOnClauses($query, $grouping, $dateValueLow[2] ?? NULL, $dateValueHigh[2] ?? NULL);
         return;
 
       case 'event_start_date_low':
@@ -728,6 +731,82 @@ class CRM_Event_BAO_Query extends CRM_Core_BAO_Query {
       'where_end' => 'civicrm_event.end_date',
       'html' => ['type' => 'SelectDate', 'formatType' => 'activityDateTime'],
     ];
+  }
+
+  /**
+   * Add the where clause & qill for the pseudo field "Event Active On".
+   *
+   * @param \CRM_Contact_BAO_Query $query
+   * @param int|string $grouping
+   * @param string|null $lowValue
+   * @param string|null $highValue
+   */
+  protected static function addEventActiveOnClauses(CRM_Contact_BAO_Query $query, $grouping, ?string $lowValue, ?string $highValue): void {
+    $from = $to = NULL;
+
+    if (!empty($lowValue)) {
+      $from = CRM_Utils_Date::processDate($lowValue, NULL, FALSE, 'YmdHis');
+    }
+
+    if (!empty($highValue)) {
+      if (strlen($highValue) === 10) {
+        $highValue .= ' 23:59:59';
+      }
+      $to = CRM_Utils_Date::processDate($highValue, NULL, FALSE, 'YmdHis');
+    }
+
+    $clause = self::getEventActiveOnClause($from, $to);
+    if (!$clause) {
+      return;
+    }
+    $query->_where[$grouping][] = $clause;
+
+    if ($from && $to) {
+      $query->_qill[$grouping][] = ts('Event Active On between "%1" and "%2"', [
+        1 => CRM_Utils_Date::customFormat($from),
+        2 => CRM_Utils_Date::customFormat($to),
+      ]);
+    }
+    elseif ($from) {
+      $query->_qill[$grouping][] = ts('Event Active on or after "%1"', [
+        1 => CRM_Utils_Date::customFormat($from),
+      ]);
+    }
+    else {
+      $query->_qill[$grouping][] = ts('Event Active on or before "%1"', [
+        1 => CRM_Utils_Date::customFormat($to),
+      ]);
+    }
+
+    $query->_tables['civicrm_event'] = 1;
+    $query->_whereTables['civicrm_event'] = 1;
+  }
+
+  /**
+   * Get the where clause matching events that are running during a date range.
+   *
+   * @param string|null $from
+   *   Start of the range, as YmdHis.
+   * @param string|null $to
+   *   End of the range, as YmdHis.
+   *
+   * @return string|null
+   *   NULL if neither end of the range was given.
+   */
+  public static function getEventActiveOnClause(?string $from, ?string $to): ?string {
+    // Events with no end date finish when they start.
+    $eventEnd = 'COALESCE(civicrm_event.end_date, civicrm_event.start_date)';
+
+    if ($from && $to) {
+      return "(civicrm_event.start_date <= '{$to}' AND {$eventEnd} >= '{$from}')";
+    }
+    if ($from) {
+      return "{$eventEnd} >= '{$from}'";
+    }
+    if ($to) {
+      return "civicrm_event.start_date <= '{$to}'";
+    }
+    return NULL;
   }
 
 }

--- a/tests/phpunit/CRM/Event/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Event/BAO/QueryTest.php
@@ -92,6 +92,131 @@ class CRM_Event_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
+   * The "Event Active On" filter should match every event that is running at
+   * some point during the search range not only events that start within it.
+   *
+   * @dataProvider getEventActiveOnSearches
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testEventActiveOn(?string $low, ?string $high, array $expected): void {
+    $this->useTransaction();
+    $events = $this->createEventsForActiveOnSearch();
+
+    $params = [];
+    if ($low !== NULL) {
+      $params[] = ['event_low', '=', $low, 0, 0];
+    }
+    if ($high !== NULL) {
+      $params[] = ['event_high', '=', $high, 0, 0];
+    }
+
+    $query = new CRM_Contact_BAO_Query(
+      $params, ['event_id' => 1], NULL,
+      FALSE, FALSE, CRM_Contact_BAO_Query::MODE_EVENT
+    );
+    $dao = CRM_Core_DAO::executeQuery(implode(' ', $query->query(FALSE)));
+
+    $found = [];
+    while ($dao->fetch()) {
+      // Ignore any events left behind by other tests in this class.
+      $identifier = array_search((int) $dao->event_id, $events, TRUE);
+      if ($identifier !== FALSE) {
+        $found[] = $identifier;
+      }
+    }
+    sort($found);
+    sort($expected);
+    $this->assertEquals($expected, $found);
+  }
+
+  /**
+   * Search ranges for "Event Active On" and the events they should return.
+   *
+   * The events being searched are set up in createEventsForActiveOnSearch().
+   *
+   * @return array
+   */
+  public static function getEventActiveOnSearches(): array {
+    return [
+      // CASE A: https://lab.civicrm.org/dev/core/-/issues/6386 : the range
+      // falls wholly inside the long running event, which used to be excluded
+      // because it started before the range.
+      'range inside a long running event' => [
+        '2026-01-15', '2026-01-20',
+        ['longer_period', 'within'],
+      ],
+      // CASE B: The range opens on the day the long running event closes, so
+      // they still overlap by a few hours.
+      'range starting on the event end date' => [
+        '2026-03-31', '2026-04-05',
+        ['longer_period'],
+      ],
+      // CASE C: The range closes on the day the long running event opens.
+      'range ending on the event start date' => [
+        '2025-12-20', '2026-01-01',
+        ['longer_period'],
+      ],
+      // CASE D: An event with no end date runs on its start date, so it is
+      // matched by a range covering that day.
+      'range covering an event with no end date' => [
+        '2026-01-10', '2026-01-10',
+        ['longer_period', 'no_end_date'],
+      ],
+      // CASE E:
+      'range starting the day after an event with no end date' => [
+        '2026-01-11', '2026-01-14',
+        ['longer_period'],
+      ],
+      // CASE F: A gap between the events, so nothing is running.
+      'range matching no events' => [
+        '2025-11-10', '2025-11-20',
+        [],
+      ],
+      // CASE G: Only a "from" date anything that had not finished by then.
+      'from date only' => [
+        '2026-01-15', NULL,
+        ['longer_period', 'within', 'no_end_date_future', 'future'],
+      ],
+      // CASE H: Only a "to" date anything that had started by then.
+      'to date only' => [
+        NULL, '2026-01-20',
+        ['longer_period', 'within', 'no_end_date', 'past'],
+      ],
+    ];
+  }
+
+  /**
+   * Create one event per scenario, each with a single participant.
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function createEventsForActiveOnSearch(): array {
+    $events = [];
+    foreach ([
+      'longer_period' => ['2026-01-01 09:00:00', '2026-03-31 17:00:00'],
+      'within' => ['2026-01-16 09:00:00', '2026-01-18 17:00:00'],
+      'no_end_date' => ['2026-01-10 09:00:00', NULL],
+      'no_end_date_future' => ['2026-09-01 09:00:00', NULL],
+      'past' => ['2025-11-01 09:00:00', '2025-11-05 17:00:00'],
+      'future' => ['2026-06-01 09:00:00', '2026-06-05 17:00:00'],
+    ] as $identifier => [$startDate, $endDate]) {
+      $event = $this->eventCreateUnpaid([
+        'title' => 'Event Active On - ' . $identifier,
+        'start_date' => $startDate,
+        'end_date' => $endDate,
+      ], $identifier);
+      $this->individualCreate([
+        'api.participant.create' => ['event_id' => $event['id']],
+      ], $identifier);
+      $events[$identifier] = (int) $event['id'];
+    }
+    return $events;
+  }
+
+  /**
    * Test provided event search parameters.
    *
    * @dataProvider getEventSearchParameters


### PR DESCRIPTION
Overview
----------------------------------------
I tracked the commit log earlier which might affect the event search and brings me this PR https://github.com/civicrm/civicrm-core/pull/15661 . PR #15661 appears to be the source of the current behavior. That PR replaced the old event-date search handling with the pseudo-field "Event Active On" and routed it through the generic dateQueryBuilder() path. As implemented, that path applies contained-within logic for a date range (start_date >= from AND end_date <= to) rather than overlap logic. As a result, an event running from 2026-01-01 to 2026-01-31 will not match a search for 2026-01-15 to 2026-01-20, even though the event is active during that period. This patch basically move the event start and end date filter construct in a separate function rather then relying on dateQueryBuilder which seems too restrictive.

Before
----------------------------------------
Both dates supplied:
```sql
  civicrm_event.start_date >= '<from>' AND civicrm_event.end_date <= '<to>'
```
That is a containment test, the event has to fit entirely inside the search range. A long-running event, or any event extends either end of the range, was dropped. Events with no end date were dropped too, since NULL fails the comparison. With only a "from" date it tested start_date >= from, so again nothing already in progress.

After
----------------------------------------
Both dates supplied:
```sql
  civicrm_event.start_date <= '<to>'
  AND (civicrm_event.end_date IS NULL OR civicrm_event.end_date >= '<from>')
```

Technical Details
----------------------------------------
event_low/event_high used to go through CRM_Contact_BAO_Query::dateQueryBuilder(), with 'end_date' passed as
$highDBFieldName. All that helper can produce is "<low field> >= from AND <high field> <= to", so there was no way to get
an overlap check out of it. The case now builds its own where clauses in addEventActiveOnClauses().

ping @seamuslee001 @eileenmcnaughton @colemanw @francescbassas 