### PR TITLE
Fix for first-time employer relationship silently skipping inherited memberships

### DIFF
--- a/CRM/Contact/BAO/Contact/Utils.php
+++ b/CRM/Contact/BAO/Contact/Utils.php
@@ -248,12 +248,15 @@ WHERE  id IN ( $idString )
    *   Contact id of the individual.
    * @param int|string $employerIDorName
    *   (id or name).
-   * @param int|null $previousEmployerID
+   * @param int|null|false $previousEmployerID
+   *   The contact's employer_id before this change, or NULL if there genuinely was
+   *   none. Pass FALSE (the default) to have it derived from the database here -
+   *   only safe when the caller hasn't already mutated the contact's employer_id.
    * @param bool $newContact
    *
    * @throws \CRM_Core_Exception
    */
-  public static function createCurrentEmployerRelationship($contactID, $employerIDorName, $previousEmployerID = NULL, $newContact = FALSE): void {
+  public static function createCurrentEmployerRelationship($contactID, $employerIDorName, $previousEmployerID = FALSE, $newContact = FALSE): void {
     if (!$employerIDorName) {
       // This function is not called in core with no organization & should not be
       // Refs CRM-15368,CRM-15547
@@ -293,6 +296,13 @@ WHERE  id IN ( $idString )
       // was a previous more complicated check.
       CRM_Core_Error::deprecatedWarning('attempting to create an employer with invalid contact types is deprecated');
       return;
+    }
+
+    // NULL must be trusted as-is, not re-derived: by now the contact's employer_id
+    // may already hold the *new* employer (Contact::add() can write it before calling
+    // this function), so re-deriving would read that back and skip relatedMemberships().
+    if ($previousEmployerID === FALSE) {
+      $previousEmployerID = $newContact ? NULL : CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'employer_id');
     }
 
     $relationshipIds = [];
@@ -342,9 +352,6 @@ WHERE  id IN ( $idString )
     }
 
     // In case we change employer, clean previous employer related records.
-    if (!$previousEmployerID && !$newContact) {
-      $previousEmployerID = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactID, 'employer_id');
-    }
     if ($previousEmployerID &&
       $previousEmployerID != $employerID
     ) {


### PR DESCRIPTION
## Summary
Setting an Individual's "Current Employer" field to an Organization that holds a relationship-based Membership, **does not create** the inherited membership when the Individual has no prior relationship history at all.  
The "Employee of" relationship *is* created correctly; the membership silently _is not_. No error, warning, or log entry is produced anywhere.

This is a separate but _related_ PR to https://github.com/civicrm/civicrm-core/pull/36820 as I was trying to find out why I couldn't replicate the behaviour in d10-master.

## Steps to reproduce in d10-master:
1. Create a (or edit an existing) Membership Type whose "Relationship Type" is configured to "Employer of" 
2. Create an Organization contact and give it a Membership of that type, status Current (or New).
3. Create an Individual contact that has ZERO relationships on record (active or inactive/expired, this precondition matters, see Cause).
4. On the Individual's contact Summary page, use the *inline* "Current Employer" field to set the Organization (not the Relationships tab's "Add Relationship" button, that path is unaffected).
5. Save.

## Current behaviour
- Relationships tab: new active "Employee of" relationship appears - correct.
- Memberships tab: **no membership** appears - the inherited membership is never created.

## Expected behaviour
The Individual should receive an inherited membership with `owner_membership_id` pointing at the Organization's membership, same as when the same Individual is given an employer via the Relationships tab, or when they already have any prior relationship on record.

## Workaround
Re-doing the assignment through the Relationships tab (Add Relationship, or Edit -> Save on the "Employee of" relationship already created by the failed attempt) reliably creates the missing membership. That path goes through `CRM_Contact_BAO_Relationship::create()` directly and never calls `createCurrentEmployerRelationship()`, it isn't affected by this bug at all. 
Re-submitting the *same* value through the Current Employer field again does not help, since on a second pass `$previousEmployerID` and the new employer ID are now genuinely equal, and the "did it change" check correctly skips `relatedMemberships()` again.

## Cause
`CRM_Contact_BAO_Contact_Utils::createCurrentEmployerRelationship()` decides whether the employer changed and thus whether to call `relatedMemberships()`, by comparing `$previousEmployerID` to the new employer ID, re-deriving it from `civicrm_contact.employer_id` whenever it's false.

`CRM_Contact_BAO_Contact::add()` pre-fetches the true previous value before saving (per CRM-10788), precisely to avoid this problem. But the save that follows can itself write the *new* employer_id directly to `civicrm_contact` (an ordinary field, submitted by callers like the inline Current Employer widget). When there was genuinely no previous employer, `$previousEmployerID` starts NULL - false, so the fallback re-derives it, reads back the value just written, concludes nothing changed, and silently skips `relatedMemberships()`. `NULL` means both "resolved: none" and "not supplied" here, and the function can't tell them apart.

## History
Introduced by 90f0b591be6 ("CRM-10146 fix - Restricted the creation of same membership and activity again", 2013-07-17), first released in 4.4.0. Before that commit, the "did employer change" check ran once, at the top of the function, before any mutation, safe. 

## Proposed fix
Distinguish the two cases with a sentinel default instead of `NULL`: 
* `FALSE` means "not supplied, derive it"; 
* `NULL`/an int means "caller already resolved this, trust it as-is" and must never be re-derived. 