### PR TITLE
Use Membership::save() api4 instead of direct BAO::create() in relAction

### DIFF
--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -123,7 +123,7 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
           'skipStatusCal' => TRUE,
           'createActivity' => TRUE,
         ];
-        CRM_Member_BAO_Membership::create($params);
+        Membership::save(FALSE)->addRecord($params)->execute();
         $relatedDisplayName = CRM_Contact_BAO_Contact::displayName($params['contact_id']);
         CRM_Core_Session::setStatus(ts('Related membership for %1 has been created.', [1 => $relatedDisplayName]),
           ts('Membership Added'), 'success');


### PR DESCRIPTION
CRM_Member_BAO_Membership::create() without a version param runs its legacy line-item/contribution processing, which CRM-16857 already established is wrong for related memberships (see the sibling createRelatedMemberships(), which uses Membership::save(FALSE) for exactly that reason). The 'createActivity' param passed here has never been read anywhere in the codebase, so this was always a no-op.

