### PR TITLE
Fix OnlineEvent getSubmittedValue to not fall back from Additional Participant form to Register (primary participant)

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1540,23 +1540,37 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
-   * Get the submitted value, accessing it from whatever form in the flow it is
-   * submitted on.
+   * Get the submitted value, accessing it from itself or any of Register, Confirm or ThankYou.
    *
-   * @todo support AdditionalParticipant forms too.
+   * Note that we need to be careful extending this to AdditionalParticipant as it could get
+   * values from Register inappropriately (e.g from a profile relating to the primary contact).
    *
    * @param string $fieldName
    *
    * @return mixed|null
    */
   public function getSubmittedValue(string $fieldName) {
-    if ($this->isShowPaymentOnConfirm() && in_array($this->getName(), ['Confirm', 'ThankYou'], TRUE)) {
+    if ($this->elementExists($fieldName)) {
+      // This field was actually added to the current page's form, so its
+      // export is authoritative - even if it's blank/NULL, that's a real
+      // answer, not a sign that the value lives on another page.
+      $value = $this->controller->exportValue($this->getName(), $fieldName);
+    }
+    elseif ($this->isShowPaymentOnConfirm() && in_array($this->getName(), ['Confirm', 'ThankYou'], TRUE)) {
       $value = $this->controller->exportValue('Confirm', $fieldName);
     }
-    else {
-      // If we are on the Confirm or ThankYou page then the submitted values
-      // were on the Register Page so we return them
+    elseif (in_array($this->getName(), ['Confirm', 'ThankYou'], TRUE)) {
+      // Confirm and ThankYou never resubmit price, profile, or payment
+      // fields - those were only ever submitted on Register.
       $value = $this->controller->exportValue('Register', $fieldName);
+    }
+    else {
+      // Register's own fields are already caught by elementExists() above.
+      // Anything else (an AdditionalParticipant page) is a separate,
+      // self-contained submission - a field not present on it genuinely
+      // doesn't apply, and must never silently resolve to the primary's
+      // Register submission instead.
+      $value = NULL;
     }
     if (!isset($value)) {
       $value = parent::getSubmittedValue($fieldName);


### PR DESCRIPTION


Overview
----------------------------------------
Fix OnlineEvent getSubmittedValue to not fall back from Additional Participant form 

Before
----------------------------------------
In order to support moving payment details from the first form (Register) to the Confirm form @mattwire  implemented getSubmittedValue() such that it tries the Register form if the field is empty. This works well for Confirm/Register/ Thank you. However for Additional Participant many fields are on both Additional Participant AND Register and I hit issues adding the function with unpredictable results

After
----------------------------------------
AdditionalParticipant is outside the fallback - since it was not part of the original reason this doesn't break that but it does avoid un-expected behaviour. There are some values that it is getting from Register (through the old horrible -$form->set() way but I think specific helpers like `->isBypassPayment()` can be added as well look at those

Tangentially - some of the usages just seem like cruft in the validate function

Technical Details
----------------------------------------
Once I tried to add more getSubmittedValue() I found hard-to-debug issues where AdditionalParticipant was falling back to grabbing values from the Register form that belonged to the primary participant.

There are no existing cases where AdditionalParticipant is getting values from this function but once I started to add it in it got unpredictable so now is a good time to do this

Comments
----------------------------------------

