### PR TITLE
REF: Extract contact summary tags to separate tpl

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -1,16 +1,6 @@
 <div class="crm-clear crm-inline-block-content">
   <div class="crm-summary-row">
-    <div class="crm-label" id="tagLink">
-      <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contactId&selectedChild=tag"}"
-         title="{ts escape='htmlattribute'}Edit Tags{/ts}">{ts}Tags{/ts}</a>
-    </div>
-    <div class="crm-content" id="tags">
-      {foreach from=$contactTag item=tagName key=tagId}
-        <span class="crm-tag-item" {if !empty($allTags.$tagId.color)}style="background-color: {$allTags.$tagId.color}; color: {$allTags.$tagId.color|colorContrast};"{/if} title="{$allTags.$tagId.description|escape}">
-          {$tagName|escape}
-        </span>
-      {/foreach}
-    </div>
+    {include file="CRM/Contact/Page/Inline/Tags.tpl" tagsLabel="{ts}Tags{/ts}"}
   </div>
   <div class="crm-summary-row">
     <div class="crm-label">{ts}Contact Type{/ts}</div>

--- a/templates/CRM/Contact/Page/Inline/Tags.tpl
+++ b/templates/CRM/Contact/Page/Inline/Tags.tpl
@@ -1,0 +1,11 @@
+<div class="crm-label" id="tagLink">
+  <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$contactId&selectedChild=tag"}"
+     title="{ts escape='htmlattribute'}Edit Tags{/ts}">{$tagsLabel|escape}</a>
+</div>
+<div class="crm-content" id="tags">
+  {foreach from=$contactTag item=tagName key=tagId}
+    <span class="crm-tag-item" {if !empty($allTags.$tagId.color)}style="background-color: {$allTags.$tagId.color}; color: {$allTags.$tagId.color|colorContrast};"{/if} title="{$allTags.$tagId.description|escape}">
+      {$tagName|escape}
+    </span>
+  {/foreach}
+</div>


### PR DESCRIPTION
This changes nothing in core, but it allows Contact Layout Editor to use the tags tpl so we get the link and the proper styling there.