### PR TITLE
PriceFieldSpecProvider - price field options cant be named yet

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/PriceFieldSpecProvider.php
+++ b/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/PriceFieldSpecProvider.php
@@ -40,7 +40,8 @@ class PriceFieldSpecProvider extends \Civi\Core\Service\AutoService implements G
         ->setType('Extra');
 
       if ($field['options'] ?? NULL) {
-        $fieldSpec->setOptions($field['options']);
+        $fieldSpec->setOptions($field['options'])
+          ->setSuffixes(['label']);
       }
 
       $spec->addFieldSpec($fieldSpec);


### PR DESCRIPTION
Overview
----------------------------------------
Price Fields with options are broken in FormBuilder since https://github.com/civicrm/civicrm-core/commit/f8c14b20b7bf86412d2356415646ada2a772d71e because it tries to use option `name`s - but these don't exist.

Before
----------------------------------------
- Adding any price field with options to a FormBuilder form is broken. 
- the field will be added with `:name` suffix

After
----------------------------------------
Works again


Technical Details
----------------------------------------
In the long run it would be good to enable the name suffix using the PriceFieldValue name - but it's not totally straightforward so will look to do that on `master`. This is narrowest fix for the regression.

I wonder if there might be other places where fields have default suffixes, including name, but the suffixes aren't actually registered?


