### PR TITLE
[6.18 stable] PriceFieldSpecProvider - price field options cant be named yet

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/PriceFieldSpecProvider.php
+++ b/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/PriceFieldSpecProvider.php
@@ -40,7 +40,8 @@ class PriceFieldSpecProvider extends \Civi\Core\Service\AutoService implements G
         ->setType('Extra');
 
       if ($field['options'] ?? NULL) {
-        $fieldSpec->setOptions($field['options']);
+        $fieldSpec->setOptions($field['options'])
+          ->setSuffixes(['label']);
       }
 
       $spec->addFieldSpec($fieldSpec);


### PR DESCRIPTION
Overview
----------------------------------------
Backport of https://github.com/civicrm/civicrm-core/pull/36835