### PR TITLE
Port: "CiviMail - Fix inability to remove recipients from a mailing (APIv4 EntitySet regression)" to 6.18

### DIFF
--- a/Civi/Api4/Query/Api4EntitySetQuery.php
+++ b/Civi/Api4/Query/Api4EntitySetQuery.php
@@ -148,6 +148,22 @@ class Api4EntitySetQuery extends Api4Query {
         $select = array_diff($select, [$item]);
       }
     }
+    // An outer expression belongs to no subquery, so without its own spec it is returned unformatted.
+    foreach ($this->selectAliases as $alias => $sql) {
+      if (isset($this->apiFieldSpec[$alias])) {
+        continue;
+      }
+      $expr = SqlExpression::convert($sql);
+      // Plain fields are resolved by base name in formatOutputValues(), which is what finds the
+      // options for a suffixed alias like `parent_id:name`; a spec keyed by the alias masks them.
+      if ($expr->getType() === 'SqlField') {
+        continue;
+      }
+      $this->addSpecField($alias, [
+        'sql_name' => "`$alias`",
+        'data_type' => $expr->getRenderedDataType($this),
+      ]);
+    }
     if ($select && !$this->isAggregateQuery()) {
       $this->selectAliases['_api_set_index'] = '_api_set_index';
       $this->query->select('`_api_set_index`');

--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -131,7 +131,7 @@ class SqlEquation extends SqlExpression {
   }
 
   /**
-   * Change $dataType according to operator used in equation
+   * Applies self::getRenderedDataType() during output formatting
    *
    * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
    * @param string|null $dataType
@@ -139,17 +139,29 @@ class SqlEquation extends SqlExpression {
    * @param string $key
    * @param Api4Query|null $query
    */
-  public function formatOutputValue(?string &$dataType, array &$values, string $key, ?Api4Query $query = NULL) {
-    foreach (self::$comparisonOperators as $op) {
-      if (strpos($this->expr, " $op ")) {
-        $dataType = 'Boolean';
-      }
-    }
+  public function formatOutputValue(?string &$dataType, array &$values, string $key, ?Api4Query $query = NULL): void {
+    $dataType = $this->getRenderedDataType($query) ?? $dataType;
+  }
+
+  /**
+   * Returns the output dataType implied by the operators used in the equation
+   *
+   * @param \Civi\Api4\Query\Api4Query|null $query
+   * @return string|null
+   */
+  public function getRenderedDataType(?Api4Query $query): ?string {
+    // Order matters: an expression using both kinds of operator is typed as Float.
     foreach (self::$arithmeticOperators as $op) {
       if (strpos($this->expr, " $op ")) {
-        $dataType = 'Float';
+        return 'Float';
       }
     }
+    foreach (self::$comparisonOperators as $op) {
+      if (strpos($this->expr, " $op ")) {
+        return 'Boolean';
+      }
+    }
+    return NULL;
   }
 
   public static function getTitle(): string {

--- a/tests/phpunit/api/v4/Action/EntitySetUnionTest.php
+++ b/tests/phpunit/api/v4/Action/EntitySetUnionTest.php
@@ -127,6 +127,56 @@ class EntitySetUnionTest extends Api4TestBase implements TransactionalInterface 
     $this->assertEquals(['Contact', 'Activity'], $result[1]['group_type:name']);
   }
 
+  public function testUnionWithOuterExpression(): void {
+    $groups = $this->saveTestRecords('Group', [
+      'records' => [
+        ['title' => 'hidden group', 'is_hidden' => TRUE],
+        ['title' => 'visible group', 'is_hidden' => FALSE],
+      ],
+    ])->column('id');
+
+    $result = EntitySet::get(FALSE)
+      ->addSelect('id', '(is_hidden = 1) AS hidden_flag')
+      ->addSet('UNION ALL', Group::get()
+        ->addSelect('id', 'is_hidden')
+        ->addWhere('id', '=', $groups[0])
+      )
+      ->addSet('UNION ALL', Group::get()
+        ->addSelect('id', 'is_hidden')
+        ->addWhere('id', '=', $groups[1])
+      )
+      ->addOrderBy('id')
+      ->execute();
+
+    $this->assertCount(2, $result);
+    // Without formatting these would be the strings "1"/"0"
+    $this->assertTrue($result[0]['hidden_flag']);
+    $this->assertFalse($result[1]['hidden_flag']);
+  }
+
+  public function testOuterExpressionNotTypedBySameNamedField(): void {
+    $tag = $this->createTestRecord('Tag', ['name' => 'union tag']);
+    $group = $this->createTestRecord('Group', ['title' => 'union group']);
+
+    $result = EntitySet::get(FALSE)
+      ->addSelect('id', 'IF((is_hidden IS NOT NULL), is_hidden, NULL) AS copied')
+      ->addSet('UNION ALL', Tag::get()
+        ->addSelect('id', 'CONCAT(name) AS is_hidden')
+        ->addWhere('id', '=', $tag['id'])
+      )
+      ->addSet('UNION ALL', Group::get()
+        ->addSelect('id', 'title')
+        ->addWhere('id', '=', $group['id'])
+      )
+      ->addOrderBy('copied')
+      ->execute();
+
+    $this->assertCount(2, $result);
+    // The union names this column after the first set's alias and both sets put a string in it,
+    // so the outer expression must not be typed from the Boolean field of that name
+    $this->assertSame(['union group', 'union tag'], $result->column('copied'));
+  }
+
   public function testGroupByUnionSet(): void {
     $contacts = $this->saveTestRecords('Contact', ['records' => 4])->column('id');
     $relationships = $this->saveTestRecords('Relationship', [


### PR DESCRIPTION
Port of #36709 to 6.18.

Fixes https://lab.civicrm.org/dev/core/-/work_items/6758